### PR TITLE
Implement basic MSDF text pipeline

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -146,6 +146,7 @@ add_library(DriftUI STATIC
   ui/src/FontSystem/FontManager.cpp
   ui/src/FontSystem/Font.cpp
   ui/src/FontSystem/FontAtlas.cpp
+  ui/src/FontSystem/MSDFGenerator.cpp
   ui/src/FontSystem/TextRenderer.cpp
 )
 

--- a/src/ui/include/Drift/UI/FontSystem/FontAtlas.h
+++ b/src/ui/include/Drift/UI/FontSystem/FontAtlas.h
@@ -1,127 +1,76 @@
 #pragma once
 
 #include <memory>
+#include <unordered_map>
 #include <vector>
 #include <glm/glm.hpp>
 #include "Drift/RHI/Texture.h"
 
 namespace Drift::UI {
 
-// Estrutura para representar uma região no atlas
 struct AtlasRegion {
-    glm::vec2 position;      // Posição no atlas (pixels)
-    glm::vec2 size;          // Tamanho da região (pixels)
-    glm::vec2 uvMin;         // Coordenadas UV mínimas
-    glm::vec2 uvMax;         // Coordenadas UV máximas
-    bool isOccupied;
-    uint32_t glyphId;        // ID do glyph associado
+    int x{0};
+    int y{0};
+    int width{0};
+    int height{0};
+    uint32_t glyphId{0};
 };
 
-// Configurações do atlas
 struct AtlasConfig {
-    int width = 2048;        // Largura do atlas em pixels
-    int height = 2048;       // Altura do atlas em pixels
-    int padding = 2;         // Padding entre glyphs
-    int channels = 4;        // Canais de cor (RGBA)
-    bool useMSDF = true;     // Usar MSDF ou bitmap normal
-    int msdfSize = 32;       // Tamanho do MSDF em pixels
+    int width = 2048;
+    int height = 2048;
+    int padding = 2;
+    int channels = 4;
+    bool useMSDF = true;
+    int msdfSize = 32;
 };
 
-// Classe para gerenciar o atlas de fontes
 class FontAtlas {
 public:
     FontAtlas(const AtlasConfig& config = AtlasConfig{});
     ~FontAtlas();
 
-    // Gerenciamento de regiões
     AtlasRegion* AllocateRegion(int width, int height, uint32_t glyphId);
-    void FreeRegion(uint32_t glyphId);
-    AtlasRegion* FindRegion(uint32_t glyphId);
-    
-    // Upload de dados
-    bool UploadGlyphData(const AtlasRegion* region, const uint8_t* data, int width, int height, int channels);
     bool UploadMSDFData(const AtlasRegion* region, const uint8_t* data, int width, int height);
-    
-    // Acesso à textura
-    Drift::RHI::ITexture* GetTexture() const { return m_Texture.get(); }
-    bool IsDirty() const { return m_IsDirty; }
-    void MarkClean() { m_IsDirty = false; }
-    
-    // Informações do atlas
-    const AtlasConfig& GetConfig() const { return m_Config; }
-    float GetUsage() const; // Percentual de uso do atlas
-    
-    // Otimização
-    void Defragment();
-    void Resize(int newWidth, int newHeight);
-
-private:
-    // Configuração do atlas
-    AtlasConfig m_Config;
-    
-    // Textura do atlas
-    std::unique_ptr<Drift::RHI::ITexture> m_Texture;
-    std::vector<uint8_t> m_TextureData;
-    bool m_IsDirty;
-    
-    // Gerenciamento de regiões
-    std::vector<AtlasRegion> m_Regions;
-    std::vector<uint32_t> m_FreeRegions;
-    
-    // Métodos internos
-    bool InitializeTexture();
-    bool FindBestFit(int width, int height, AtlasRegion& region);
-    void SplitRegion(AtlasRegion& region, int width, int height);
-    void MergeAdjacentRegions();
-    void UpdateTextureData();
-    
-    // Algoritmo de empacotamento
-    struct PackingNode {
-        glm::vec2 position;
-        glm::vec2 size;
-        bool isLeaf;
-        std::unique_ptr<PackingNode> left;
-        std::unique_ptr<PackingNode> right;
-    };
-    
-    std::unique_ptr<PackingNode> m_PackingTree;
-    bool InsertIntoTree(PackingNode* node, int width, int height, AtlasRegion& region);
-    void RebuildPackingTree();
-};
-
-// Gerenciador de múltiplos atlas (para fontes grandes)
-class MultiAtlasManager {
-public:
-    MultiAtlasManager(const AtlasConfig& baseConfig = AtlasConfig{});
-    ~MultiAtlasManager();
-
-    // Alocação de glyphs
-    AtlasRegion* AllocateGlyph(int width, int height, uint32_t glyphId);
-    void FreeGlyph(uint32_t glyphId);
-    AtlasRegion* FindGlyph(uint32_t glyphId);
-    
-    // Upload de dados
-    bool UploadGlyphData(uint32_t glyphId, const uint8_t* data, int width, int height, int channels);
-    bool UploadMSDFData(uint32_t glyphId, const uint8_t* data, int width, int height);
-    
-    // Acesso às texturas
-    std::vector<Drift::RHI::ITexture*> GetTextures() const;
-    bool HasDirtyTextures() const;
-    void MarkAllClean();
-    
-    // Otimização
-    void Optimize();
+    AtlasRegion* GetRegion(uint32_t glyphId) const;
+    bool HasRegion(uint32_t glyphId) const;
     void Clear();
 
+    size_t GetRegionCount() const;
+    float GetUsagePercentage() const;
+
+    Drift::RHI::ITexture* GetTexture() const;
+    int GetWidth() const;
+    int GetHeight() const;
+    const AtlasConfig& GetConfig() const;
+
 private:
-    AtlasConfig m_BaseConfig;
-    std::vector<std::unique_ptr<FontAtlas>> m_Atlases;
-    std::unordered_map<uint32_t, std::pair<FontAtlas*, AtlasRegion*>> m_GlyphMap;
-    
-    // Métodos internos
-    FontAtlas* FindAtlasWithSpace(int width, int height);
-    FontAtlas* CreateNewAtlas();
-    void RebalanceAtlases();
+    AtlasConfig m_Config;
+    std::unique_ptr<Drift::RHI::ITexture> m_Texture;
+    int m_Width{0};
+    int m_Height{0};
+    int m_CurrentX{0};
+    int m_CurrentY{0};
+    int m_LineHeight{0};
+
+    std::unordered_map<uint32_t, std::unique_ptr<AtlasRegion>> m_Regions;
 };
 
-} // namespace Drift::UI 
+class MultiAtlasManager {
+public:
+    explicit MultiAtlasManager(const AtlasConfig& defaultConfig = AtlasConfig{});
+    ~MultiAtlasManager();
+
+    FontAtlas* CreateAtlas(const AtlasConfig& config);
+    FontAtlas* GetAtlasForGlyph(uint32_t glyphId);
+    void Clear();
+
+    size_t GetAtlasCount() const;
+    const std::vector<std::unique_ptr<FontAtlas>>& GetAtlases() const;
+
+private:
+    AtlasConfig m_DefaultConfig;
+    std::vector<std::unique_ptr<FontAtlas>> m_Atlases;
+};
+
+} // namespace Drift::UI

--- a/src/ui/src/FontSystem/MSDFGenerator.cpp
+++ b/src/ui/src/FontSystem/MSDFGenerator.cpp
@@ -1,0 +1,230 @@
+#include "Drift/UI/FontSystem/MSDFGenerator.h"
+#include "Drift/Core/Log.h"
+#include "stb_truetype.h"
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace Drift::UI {
+
+MSDFGenerator::MSDFGenerator(const MSDFConfig& config)
+    : m_Config(config) {}
+
+MSDFGenerator::~MSDFGenerator() = default;
+
+bool MSDFGenerator::GenerateFromGlyph(const void* fontData, uint32_t codepoint, MSDFData& output) {
+    if (!fontData) {
+        return false;
+    }
+
+    stbtt_fontinfo info;
+    if (!stbtt_InitFont(&info, reinterpret_cast<const unsigned char*>(fontData), 0)) {
+        LOG_ERROR("stbtt_InitFont failed in MSDFGenerator");
+        return false;
+    }
+
+    float scale = stbtt_ScaleForPixelHeight(&info, static_cast<float>(m_Config.height));
+    int w, h, xoff, yoff;
+    unsigned char* sdf = stbtt_GetCodepointSDF(&info, scale, static_cast<int>(codepoint), m_Config.range,
+                                              128, 1.0f, &w, &h, &xoff, &yoff);
+    if (!sdf) {
+        LOG_ERROR("stbtt_GetCodepointSDF failed for codepoint {}", codepoint);
+        return false;
+    }
+
+    output.width = w;
+    output.height = h;
+    output.range = static_cast<float>(m_Config.range);
+    size_t count = static_cast<size_t>(w) * static_cast<size_t>(h);
+    output.red.resize(count);
+    output.green.resize(count);
+    output.blue.resize(count);
+    output.alpha.resize(count);
+
+    for (size_t i = 0; i < count; ++i) {
+        float v = sdf[i] / 255.0f;
+        output.red[i] = v;
+        output.green[i] = v;
+        output.blue[i] = v;
+        output.alpha[i] = v;
+    }
+
+    STBTT_free(sdf, nullptr);
+    return true;
+}
+
+bool MSDFGenerator::GenerateFromContours(const std::vector<Contour>&, MSDFData&) {
+    // Implementação simplificada não suporta contornos customizados
+    return false;
+}
+
+bool MSDFGenerator::ConvertToRGBA8(const MSDFData& msdf, std::vector<uint8_t>& output) {
+    if (msdf.red.empty()) {
+        return false;
+    }
+    output.resize(msdf.red.size() * 4);
+    for (size_t i = 0; i < msdf.red.size(); ++i) {
+        output[i * 4 + 0] = static_cast<uint8_t>(std::clamp(msdf.red[i], 0.0f, 1.0f) * 255.0f);
+        output[i * 4 + 1] = static_cast<uint8_t>(std::clamp(msdf.green[i], 0.0f, 1.0f) * 255.0f);
+        output[i * 4 + 2] = static_cast<uint8_t>(std::clamp(msdf.blue[i], 0.0f, 1.0f) * 255.0f);
+        output[i * 4 + 3] = static_cast<uint8_t>(std::clamp(msdf.alpha[i], 0.0f, 1.0f) * 255.0f);
+    }
+    return true;
+}
+
+bool MSDFGenerator::ConvertToRGBA32F(const MSDFData& msdf, std::vector<float>& output) {
+    if (msdf.red.empty()) {
+        return false;
+    }
+    output.resize(msdf.red.size() * 4);
+    for (size_t i = 0; i < msdf.red.size(); ++i) {
+        output[i * 4 + 0] = msdf.red[i];
+        output[i * 4 + 1] = msdf.green[i];
+        output[i * 4 + 2] = msdf.blue[i];
+        output[i * 4 + 3] = msdf.alpha[i];
+    }
+    return true;
+}
+
+void MSDFGenerator::ApplyAntiAliasing(MSDFData& msdf, float smoothing) {
+    for (auto& v : msdf.alpha) {
+        v = std::clamp(v / (1.0f + smoothing), 0.0f, 1.0f);
+    }
+}
+
+void MSDFGenerator::ApplySubpixelRendering(MSDFData& msdf, float gamma) {
+    float invGamma = 1.0f / gamma;
+    for (auto& v : msdf.red) v = std::pow(v, invGamma);
+    for (auto& v : msdf.green) v = std::pow(v, invGamma);
+    for (auto& v : msdf.blue) v = std::pow(v, invGamma);
+}
+
+void MSDFGenerator::ApplyContrastEnhancement(MSDFData& msdf, float contrast) {
+    for (auto& v : msdf.alpha) {
+        v = std::clamp(v * (1.0f + contrast), 0.0f, 1.0f);
+    }
+}
+
+FontProcessor::FontProcessor() : m_Size(32.0f), m_Hinting(true), m_Kerning(true) {}
+FontProcessor::~FontProcessor() = default;
+
+struct FontProcessor::FontData {
+    stbtt_fontinfo info;
+    std::vector<unsigned char> buffer;
+    float ascender{};
+    float descender{};
+    float lineHeight{};
+};
+
+bool FontProcessor::LoadFont(const std::string& filePath) {
+    std::ifstream file(filePath, std::ios::binary);
+    if (!file) {
+        LOG_ERROR("Failed to open font file {}", filePath);
+        return false;
+    }
+    file.seekg(0, std::ios::end);
+    size_t len = static_cast<size_t>(file.tellg());
+    file.seekg(0, std::ios::beg);
+    m_FontData = std::make_unique<FontData>();
+    m_FontData->buffer.resize(len);
+    file.read(reinterpret_cast<char*>(m_FontData->buffer.data()), len);
+    file.close();
+    return InitializeFont();
+}
+
+bool FontProcessor::LoadFontFromMemory(const void* data, size_t dataSize) {
+    m_FontData = std::make_unique<FontData>();
+    m_FontData->buffer.resize(dataSize);
+    std::memcpy(m_FontData->buffer.data(), data, dataSize);
+    return InitializeFont();
+}
+
+bool FontProcessor::InitializeFont() {
+    if (!m_FontData) return false;
+    if (!stbtt_InitFont(&m_FontData->info, m_FontData->buffer.data(), 0)) {
+        LOG_ERROR("stbtt_InitFont failed in FontProcessor");
+        return false;
+    }
+    float scale = stbtt_ScaleForPixelHeight(&m_FontData->info, m_Size);
+    int ascent, descent, lineGap;
+    stbtt_GetFontVMetrics(&m_FontData->info, &ascent, &descent, &lineGap);
+    m_FontData->ascender = ascent * scale;
+    m_FontData->descender = -descent * scale;
+    m_FontData->lineHeight = (ascent - descent + lineGap) * scale;
+    return true;
+}
+
+bool FontProcessor::ExtractGlyph(uint32_t codepoint, std::vector<Contour>&) {
+    // Contour extraction not implemented in simplified version
+    return false;
+}
+
+bool FontProcessor::ExtractGlyphMetrics(uint32_t codepoint, float& width, float& height,
+                                        float& bearingX, float& bearingY, float& advance) {
+    if (!m_FontData) return false;
+    int glyph = stbtt_FindGlyphIndex(&m_FontData->info, static_cast<int>(codepoint));
+    int ax, lsb;
+    stbtt_GetGlyphHMetrics(&m_FontData->info, glyph, &ax, &lsb);
+    int x0, y0, x1, y1;
+    stbtt_GetGlyphBitmapBox(&m_FontData->info, glyph, stbtt_ScaleForPixelHeight(&m_FontData->info, m_Size),
+                            stbtt_ScaleForPixelHeight(&m_FontData->info, m_Size), &x0, &y0, &x1, &y1);
+    width = static_cast<float>(x1 - x0);
+    height = static_cast<float>(y1 - y0);
+    bearingX = static_cast<float>(x0);
+    bearingY = static_cast<float>(y0);
+    advance = static_cast<float>(ax);
+    return true;
+}
+
+float FontProcessor::GetAscender() const { return m_FontData ? m_FontData->ascender : 0.0f; }
+float FontProcessor::GetDescender() const { return m_FontData ? m_FontData->descender : 0.0f; }
+float FontProcessor::GetLineHeight() const { return m_FontData ? m_FontData->lineHeight : m_Size; }
+float FontProcessor::GetBaseline() const { return GetAscender(); }
+
+FontProcessingPipeline::FontProcessingPipeline()
+    : m_Processor(std::make_unique<FontProcessor>()),
+      m_Generator(std::make_unique<MSDFGenerator>()),
+      m_Quality(FontQuality::High), m_Smoothing(0.1f), m_Contrast(0.1f), m_Gamma(2.2f) {}
+
+FontProcessingPipeline::~FontProcessingPipeline() = default;
+
+bool FontProcessingPipeline::ProcessGlyph(uint32_t codepoint, MSDFData& output, const MSDFConfig& config) {
+    m_Generator->SetConfig(config);
+    if (!m_Generator || !m_Processor) return false;
+    return m_Generator->GenerateFromGlyph(m_Processor->m_FontData->buffer.data(), codepoint, output);
+}
+
+bool FontProcessingPipeline::ProcessFont(const std::string& fontPath, const std::string&, const MSDFConfig& config) {
+    if (!m_Processor->LoadFont(fontPath)) {
+        return false;
+    }
+    m_Generator->SetConfig(config);
+    return true;
+}
+
+void FontProcessingPipeline::SetQuality(FontQuality quality) { m_Quality = quality; }
+void FontProcessingPipeline::SetAntiAliasingSettings(float smoothing, float contrast, float gamma) {
+    m_Smoothing = smoothing;
+    m_Contrast = contrast;
+    m_Gamma = gamma;
+}
+
+MSDFConfig FontProcessingPipeline::GetConfigForQuality(FontQuality quality) {
+    MSDFConfig cfg;
+    switch (quality) {
+    case FontQuality::Low: cfg.range = 8; break;
+    case FontQuality::Medium: cfg.range = 16; break;
+    case FontQuality::High: cfg.range = 32; break;
+    case FontQuality::Ultra: cfg.range = 64; break;
+    }
+    return cfg;
+}
+
+void FontProcessingPipeline::ApplyQualitySettings(MSDFData& msdf) {
+    if (m_Smoothing > 0.0f) m_Generator->ApplyAntiAliasing(msdf, m_Smoothing);
+    if (m_Contrast > 0.0f) m_Generator->ApplyContrastEnhancement(msdf, m_Contrast);
+    if (m_Gamma > 0.0f) m_Generator->ApplySubpixelRendering(msdf, m_Gamma);
+}
+
+} // namespace Drift::UI
+

--- a/src/ui/src/FontSystem/TextRenderer.cpp
+++ b/src/ui/src/FontSystem/TextRenderer.cpp
@@ -150,8 +150,9 @@ void TextRenderer::ProcessTextCommand(const TextRenderCommand& command) {
             float glyphX = currentX + glyph->offset.x;
             float glyphY = currentY - glyph->offset.y;
             
-            LOG_DEBUG("  Glyph '{}' at ({}, {}) size {}x{}", 
-                      c, glyphX, glyphY, glyph->size.x, glyph->size.y);
+            LOG_DEBUG("  Glyph '{}' at ({}, {}) size {}x{} uv ({}, {})-({}, {})",
+                      c, glyphX, glyphY, glyph->size.x, glyph->size.y,
+                      glyph->uvMin.x, glyph->uvMin.y, glyph->uvMax.x, glyph->uvMax.y);
             
             currentX += glyph->advance;
             


### PR DESCRIPTION
## Summary
- add simplified MSDF generator using stb_truetype SDF
- update FontAtlas interface and implementation
- generate MSDF glyphs when loading fonts
- log atlas UV info during text rendering
- build system now compiles new file

## Testing
- `cmake ..` *(fails: The source directory /workspace/DriftEngine/extern/DirectXTK does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68838394e50083259bca698a1aaf701f