### PR TITLE
Fix negative height in LayoutHorizontal

### DIFF
--- a/src/app/layout_fixes_test.cpp
+++ b/src/app/layout_fixes_test.cpp
@@ -380,7 +380,43 @@ void TestLayoutFixes(UI::UIContext* uiContext)
         
         responsiveTestPanel->AddChild(button);
     }
-    
+
+    // ========================================
+    // TESTE 5B: MARGENS EXTREMAS
+    // Elemento com margens verticais maiores que o container
+    // ========================================
+    auto negativeMarginPanel = std::make_shared<UI::Panel>(uiContext);
+    negativeMarginPanel->SetName("NegativeMarginPanel");
+    negativeMarginPanel->SetColor(0xFF444444);
+    negativeMarginPanel->SetSize({300.0f, 30.0f});
+
+    UI::LayoutProperties negativeLayout;
+    negativeLayout.horizontalAlign = UI::LayoutProperties::HorizontalAlign::Stretch;
+    negativeLayout.verticalAlign = UI::LayoutProperties::VerticalAlign::Stretch;
+    negativeLayout.layoutType = UI::LayoutType::Stack;
+    negativeLayout.stackDirection = UI::StackDirection::Horizontal;
+    negativeLayout.stackSpacing = 5.0f;
+    negativeLayout.margin = UI::LayoutMargins(5.0f).ToVec4();
+    negativeMarginPanel->SetLayoutProperties(negativeLayout);
+
+    testContainer->AddChild(negativeMarginPanel);
+
+    // Botão que antes gerava altura negativa
+    auto negativeButton = std::make_shared<UI::Button>(uiContext);
+    negativeButton->SetName("NegativeMarginButton");
+    negativeButton->SetText("Margens Grandes");
+    negativeButton->SetSize({80.0f, 20.0f});
+    negativeButton->SetNormalColor(0xFF607D8B);
+
+    UI::LayoutProperties negativeButtonLayout;
+    negativeButtonLayout.horizontalAlign = UI::LayoutProperties::HorizontalAlign::Left;
+    negativeButtonLayout.verticalAlign = UI::LayoutProperties::VerticalAlign::Stretch;
+    negativeButtonLayout.layoutType = UI::LayoutType::None;
+    negativeButtonLayout.margin = UI::LayoutMargins(0.0f, 25.0f, 0.0f, 25.0f).ToVec4();
+    negativeButton->SetLayoutProperties(negativeButtonLayout);
+
+    negativeMarginPanel->AddChild(negativeButton);
+
     // ========================================
     // TESTE 6: CONTROLES
     // ========================================

--- a/src/ui/src/LayoutEngine.cpp
+++ b/src/ui/src/LayoutEngine.cpp
@@ -221,6 +221,8 @@ void LayoutEngine::LayoutHorizontal(const std::vector<std::shared_ptr<UIElement>
         } else if (childProps.verticalAlign == LayoutProperties::VerticalAlign::Stretch) {
             y = parentRect.y + marginTop;
             childSize.y = parentRect.height - marginTop - marginBottom;
+            // Garante que o tamanho não seja negativo
+            if (childSize.y < 0) childSize.y = 0;
         }
         
         // Verifica se o elemento ultrapassa os limites do container pai (horizontal)


### PR DESCRIPTION
## Summary
- clamp calculated height in `LayoutHorizontal` when using stretch alignment
- add layout-fix test with large vertical margins

## Testing
- `cmake -S . -B build` *(fails: RandR headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_68839bff48308325ab9ef1db04fa49a8