### PR TITLE
Fix input handling with clipping

### DIFF
--- a/src/app/clipping_test.cpp
+++ b/src/app/clipping_test.cpp
@@ -129,7 +129,8 @@ void TestClippingSystem(UI::UIContext* uiContext)
     button4->SetLayoutProperties(button4Layout);
     
     button4->SetOnClick([](const UI::ButtonClickEvent& event) {
-        Core::Log("[Clipping Test] Botão Fora dos Limites clicado!");
+        // Este log não deve aparecer se o clipping estiver funcionando
+        Core::Log("[Clipping Test][ERRO] Botão Fora dos Limites clicado!");
     });
     
     mainContainer->AddChild(button4);
@@ -173,6 +174,7 @@ void TestClippingSystem(UI::UIContext* uiContext)
         subButton->SetLayoutProperties(subButtonLayout);
         
         subButton->SetOnClick([i](const UI::ButtonClickEvent& event) {
+            // Apenas os botões visíveis dentro do clipping devem responder
             Core::Log("[Clipping Test] Sub Botão " + std::to_string(i + 1) + " clicado!");
         });
         

--- a/src/ui/src/UIInputHandler.cpp
+++ b/src/ui/src/UIInputHandler.cpp
@@ -97,22 +97,28 @@ UIElement* UIInputHandler::GetElementAtPosition(const glm::vec2& position)
 UIElement* UIInputHandler::FindElementAtPosition(UIElement* element, const glm::vec2& position)
 {
     if (!element) return nullptr;
-    
-    // Verifica se o ponto está dentro deste elemento
-    if (IsPointInElement(element, position)) {
-        // Busca recursivamente nos filhos (em ordem reversa para pegar o topo primeiro)
-        auto& children = element->GetChildren();
-        for (auto it = children.rbegin(); it != children.rend(); ++it) {
-            auto* childResult = FindElementAtPosition(it->get(), position);
-            if (childResult) {
-                return childResult;
-            }
+
+    const bool pointInside = IsPointInElement(element, position);
+
+    // Se o elemento clippa seu conteúdo e o ponto está fora, ignora a busca nos filhos
+    if (element->GetLayoutProperties().clipContent && !pointInside) {
+        return nullptr;
+    }
+
+    // Busca recursivamente nos filhos (em ordem reversa para pegar o topo primeiro)
+    auto& children = element->GetChildren();
+    for (auto it = children.rbegin(); it != children.rend(); ++it) {
+        auto* childResult = FindElementAtPosition(it->get(), position);
+        if (childResult) {
+            return childResult;
         }
-        
-        // Se não encontrou nenhum filho, retorna este elemento
+    }
+
+    // Retorna este elemento apenas se o ponto estiver dentro dele
+    if (pointInside) {
         return element;
     }
-    
+
     return nullptr;
 }
 


### PR DESCRIPTION
## Summary
- respect `clipContent` flag when finding elements under the mouse
- update clipping test to highlight clicks on clipped widgets

## Testing
- `cmake ..` *(fails: RandR headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_68839bffc72c8325bd9024cf699b498b