### PR TITLE
Fix Panel background color update and add test

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -196,6 +196,22 @@ add_executable(LayoutFixesTest
   app/layout_fixes_test.cpp
 )
 
+add_executable(PanelColorTest
+  app/panel_color_test.cpp
+)
+
+target_include_directories(PanelColorTest PUBLIC
+  core/include
+  engine/include
+  ui/include
+)
+
+target_link_libraries(PanelColorTest PUBLIC
+  DriftCore
+  DriftEngine
+  DriftUI
+)
+
 add_executable(TexturePipeline
   tools/texture_pipeline.cpp
 )

--- a/src/app/panel_color_test.cpp
+++ b/src/app/panel_color_test.cpp
@@ -1,0 +1,23 @@
+#include "Drift/UI/UIContext.h"
+#include "Drift/UI/Widgets/Panel.h"
+#include <memory>
+#include <iostream>
+
+using namespace Drift;
+
+int main() {
+    UI::UIContext ctx;
+    ctx.Initialize();
+
+    auto panel = std::make_shared<UI::Panel>(&ctx);
+    unsigned newColor = 0xFF123456;
+    panel->SetBackgroundColor(newColor);
+
+    if (panel->GetRenderColor() != newColor) {
+        std::cerr << "Background color not updated!" << std::endl;
+        return 1;
+    }
+
+    std::cout << "Background color update success." << std::endl;
+    return 0;
+}

--- a/src/ui/include/Drift/UI/Widgets/Panel.h
+++ b/src/ui/include/Drift/UI/Widgets/Panel.h
@@ -11,7 +11,11 @@ public:
     ~Panel() override = default;
 
     // === PROPRIEDADES ESPECÍFICAS ===
-    void SetBackgroundColor(unsigned color) { m_BackgroundColor = color; }
+    void SetBackgroundColor(unsigned color)
+    {
+        m_BackgroundColor = color;
+        SetColor(color); // Keep the render color in sync
+    }
     unsigned GetBackgroundColor() const { return m_BackgroundColor; }
     
     void SetBorderColor(unsigned color) { m_BorderColor = color; }


### PR DESCRIPTION
## Summary
- change `Panel::SetBackgroundColor` so it sets the widget color too
- add a small runtime test that checks the background color update
- expose the new test executable via CMake

## Testing
- `cmake -S . -B build` *(fails: RandR headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_68839bfa8ef08325a2be712ae2ced6a2