### PR TITLE
Clipping-aware HitTest in UIContext

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -203,6 +203,10 @@ add_executable(LayoutPropagationTest
   app/layout_propagation_test.cpp
 )
 
+add_executable(HitTestClippingTest
+  app/hittest_clipping_test.cpp
+)
+
 target_include_directories(PanelColorTest PUBLIC
   core/include
   engine/include
@@ -222,6 +226,18 @@ target_include_directories(LayoutPropagationTest PUBLIC
 )
 
 target_link_libraries(LayoutPropagationTest PUBLIC
+  DriftCore
+  DriftEngine
+  DriftUI
+)
+
+target_include_directories(HitTestClippingTest PUBLIC
+  core/include
+  engine/include
+  ui/include
+)
+
+target_link_libraries(HitTestClippingTest PUBLIC
   DriftCore
   DriftEngine
   DriftUI

--- a/src/app/hittest_clipping_test.cpp
+++ b/src/app/hittest_clipping_test.cpp
@@ -1,0 +1,37 @@
+#include "Drift/UI/UIContext.h"
+#include "Drift/UI/Widgets/Panel.h"
+#include <memory>
+#include <iostream>
+
+using namespace Drift;
+
+int main() {
+    UI::UIContext ctx;
+    ctx.Initialize();
+    ctx.SetScreenSize(200.0f, 200.0f);
+
+    auto parent = std::make_shared<UI::Panel>(&ctx);
+    parent->SetSize({100.0f, 100.0f});
+    UI::LayoutProperties layout;
+    layout.layoutType = UI::LayoutType::None;
+    layout.clipContent = true;
+    parent->SetLayoutProperties(layout);
+    ctx.GetRoot()->AddChild(parent);
+
+    auto child = std::make_shared<UI::Panel>(&ctx);
+    child->SetSize({50.0f, 50.0f});
+    child->SetPosition({110.0f, 10.0f});
+    child->SetLayoutProperties(layout);
+    parent->AddChild(child);
+
+    ctx.Update(0.0f);
+
+    UI::UIElement* hit = ctx.HitTest({120.0f, 20.0f});
+    if (hit != ctx.GetRoot().get()) {
+        std::cerr << "HitTest ignored clipping" << std::endl;
+        return 1;
+    }
+
+    std::cout << "HitTest respects clipping." << std::endl;
+    return 0;
+}

--- a/src/ui/include/Drift/UI/UIContext.h
+++ b/src/ui/include/Drift/UI/UIContext.h
@@ -23,6 +23,7 @@ class UIElement;
 class UIInputHandler;
 
 class UIContext {
+    friend class UIInputHandler;
 public:
     UIContext();
     ~UIContext();
@@ -58,6 +59,7 @@ public:
     UIElement* HitTest(const glm::vec2& point);
 
 private:
+    UIElement* FindElementAtPosition(UIElement* element, const glm::vec2& point) const;
     std::shared_ptr<Drift::Engine::EventBus> m_EventBus;
 
     std::unique_ptr<LayoutEngine> m_LayoutEngine;

--- a/src/ui/include/Drift/UI/UIInputHandler.h
+++ b/src/ui/include/Drift/UI/UIInputHandler.h
@@ -31,12 +31,6 @@ public:
 private:
     // Processa eventos de mouse usando o sistema de input da Engine
     void ProcessMouseInput();
-    
-    // Busca recursiva por elementos em uma posição
-    UIElement* FindElementAtPosition(UIElement* element, const glm::vec2& position);
-    
-    // Verifica se um ponto está dentro de um elemento
-    bool IsPointInElement(const UIElement* element, const glm::vec2& point) const;
 
     UIContext* m_Context;
     Drift::Engine::Input::IInputManager* m_InputManager{nullptr};

--- a/src/ui/src/UIContext.cpp
+++ b/src/ui/src/UIContext.cpp
@@ -146,10 +146,29 @@ std::shared_ptr<Drift::Engine::EventBus> UIContext::GetEventBus() const
     return m_EventBus;
 }
 
+UIElement* UIContext::FindElementAtPosition(UIElement* element, const glm::vec2& point) const
+{
+    if (!element) return nullptr;
+
+    const bool pointInside = element->HitTest(point);
+
+    if (element->GetLayoutProperties().clipContent && !pointInside)
+        return nullptr;
+
+    auto& children = element->GetChildren();
+    for (auto it = children.rbegin(); it != children.rend(); ++it) {
+        if (UIElement* childHit = FindElementAtPosition(it->get(), point)) {
+            return childHit;
+        }
+    }
+
+    return pointInside ? element : nullptr;
+}
+
 UIElement* UIContext::HitTest(const glm::vec2& point)
 {
     if (m_Root) {
-        return m_Root->HitTestChildren(point);
+        return FindElementAtPosition(m_Root.get(), point);
     }
     return nullptr;
-} 
+}

--- a/src/ui/src/UIInputHandler.cpp
+++ b/src/ui/src/UIInputHandler.cpp
@@ -90,46 +90,6 @@ UIElement* UIInputHandler::GetElementAtPosition(const glm::vec2& position)
 {
     auto* root = m_Context->GetRoot().get();
     if (!root) return nullptr;
-    
-    return FindElementAtPosition(root, position);
+
+    return m_Context->FindElementAtPosition(root, position);
 }
-
-UIElement* UIInputHandler::FindElementAtPosition(UIElement* element, const glm::vec2& position)
-{
-    if (!element) return nullptr;
-
-    const bool pointInside = IsPointInElement(element, position);
-
-    // Se o elemento clippa seu conteúdo e o ponto está fora, ignora a busca nos filhos
-    if (element->GetLayoutProperties().clipContent && !pointInside) {
-        return nullptr;
-    }
-
-    // Busca recursivamente nos filhos (em ordem reversa para pegar o topo primeiro)
-    auto& children = element->GetChildren();
-    for (auto it = children.rbegin(); it != children.rend(); ++it) {
-        auto* childResult = FindElementAtPosition(it->get(), position);
-        if (childResult) {
-            return childResult;
-        }
-    }
-
-    // Retorna este elemento apenas se o ponto estiver dentro dele
-    if (pointInside) {
-        return element;
-    }
-
-    return nullptr;
-}
-
-bool UIInputHandler::IsPointInElement(const UIElement* element, const glm::vec2& point) const
-{
-    if (!element) return false;
-    
-    // Usa posição absoluta para considerar a hierarquia de elementos
-    glm::vec2 absPos = element->GetAbsolutePosition();
-    glm::vec2 size = element->GetSize();
-    
-    return point.x >= absPos.x && point.x <= absPos.x + size.x &&
-           point.y >= absPos.y && point.y <= absPos.y + size.y;
-} 


### PR DESCRIPTION
## Summary
- implement recursive clipping logic in `UIContext::HitTest`
- expose helper `FindElementAtPosition` in `UIContext` and reuse it from `UIInputHandler`
- add unit test verifying clipping-aware hit testing
- hook test in CMake build

## Testing
- `cmake -B build` *(fails: RandR headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883a0bfabfc8325b5dbdc01d4287250