### PR TITLE
Support rotation for UI quads

### DIFF
--- a/src/app/layout_test.cpp
+++ b/src/app/layout_test.cpp
@@ -99,6 +99,9 @@ void TestLayoutSystem(UI::UIContext* uiContext)
         
         button->SetHoverColor(hoverColor);
         button->SetPressedColor(pressedColor);
+        if (i == 0) {
+            button->SetRotation(glm::radians(30.0f));
+        }
         
         // Layout que ocupa toda a largura horizontal
         UI::LayoutProperties buttonLayout;

--- a/src/rhi/include/Drift/RHI/Buffer.h
+++ b/src/rhi/include/Drift/RHI/Buffer.h
@@ -3,6 +3,8 @@
 #include <memory>
 #include <cstddef>
 #include "Drift/RHI/Resource.h"
+#include <glm/mat4x4.hpp>
+#include <glm/vec4.hpp>
 
 namespace Drift::RHI {
 
@@ -58,6 +60,18 @@ namespace Drift::RHI {
         virtual ~IUIBatcher() = default;
         virtual void Begin() = 0; // Inicia um novo batch
         virtual void AddRect(float x, float y, float w, float h, unsigned color) = 0; // Adiciona retângulo
+        virtual void AddQuad(float x0, float y0,
+                             float x1, float y1,
+                             float x2, float y2,
+                             float x3, float y3,
+                             unsigned color) = 0; // Adiciona quad genérico
+        virtual void AddQuad(const glm::mat4& transform, float w, float h, unsigned color) {
+            glm::vec4 p0 = transform * glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);
+            glm::vec4 p1 = transform * glm::vec4(w, 0.0f, 0.0f, 1.0f);
+            glm::vec4 p2 = transform * glm::vec4(w, h, 0.0f, 1.0f);
+            glm::vec4 p3 = transform * glm::vec4(0.0f, h, 0.0f, 1.0f);
+            AddQuad(p0.x, p0.y, p1.x, p1.y, p2.x, p2.y, p3.x, p3.y, color);
+        }
         virtual void AddText(float x, float y, const char* text, unsigned color) = 0;  // Adiciona texto
         virtual void End() = 0;   // Finaliza e envia draw calls
 

--- a/src/rhi_dx11/include/Drift/RHI/DX11/UIBatcherDX11.h
+++ b/src/rhi_dx11/include/Drift/RHI/DX11/UIBatcherDX11.h
@@ -27,6 +27,9 @@ public:
     UIBatcherDX11(std::shared_ptr<IRingBuffer> ringBuffer, Drift::RHI::IContext* ctx);
     void Begin() override;
     void AddRect(float x, float y, float w, float h, unsigned color) override;
+    void AddQuad(float x0, float y0, float x1, float y1,
+                 float x2, float y2, float x3, float y3,
+                 unsigned color) override;
     void AddText(float x, float y, const char* text, unsigned color) override;
     void End() override;
 

--- a/src/rhi_dx11/src/UIBatcherDX11.cpp
+++ b/src/rhi_dx11/src/UIBatcherDX11.cpp
@@ -84,6 +84,38 @@ void UIBatcherDX11::AddRect(float x, float y, float w, float h, unsigned color) 
     _indices.push_back(base + 0);
 }
 
+void UIBatcherDX11::AddQuad(float x0, float y0, float x1, float y1,
+                            float x2, float y2, float x3, float y3,
+                            unsigned color) {
+    ScissorRect currentScissor = GetCurrentScissorRect();
+    if (currentScissor.IsValid()) {
+        float minX = std::min({x0, x1, x2, x3});
+        float minY = std::min({y0, y1, y2, y3});
+        float maxX = std::max({x0, x1, x2, x3});
+        float maxY = std::max({y0, y1, y2, y3});
+        if (maxX <= currentScissor.x || minX >= currentScissor.x + currentScissor.width ||
+            maxY <= currentScissor.y || minY >= currentScissor.y + currentScissor.height) {
+            return;
+        }
+    }
+
+    auto toClipX = [this](float px) { return (px / _screenW) * 2.0f - 1.0f; };
+    auto toClipY = [this](float py) { return 1.0f - (py / _screenH) * 2.0f; };
+
+    unsigned bgra = ConvertARGBtoBGRA(color);
+    unsigned base = (unsigned)_vertices.size();
+    _vertices.push_back({toClipX(x0), toClipY(y0), bgra});
+    _vertices.push_back({toClipX(x1), toClipY(y1), bgra});
+    _vertices.push_back({toClipX(x2), toClipY(y2), bgra});
+    _vertices.push_back({toClipX(x3), toClipY(y3), bgra});
+    _indices.push_back(base + 0);
+    _indices.push_back(base + 1);
+    _indices.push_back(base + 2);
+    _indices.push_back(base + 2);
+    _indices.push_back(base + 3);
+    _indices.push_back(base + 0);
+}
+
 // Implementação do sistema de renderização de texto com MSDF
 void UIBatcherDX11::AddText(float x, float y, const char* text, unsigned color) {
     if (!text || !_textRenderer) {

--- a/src/ui/src/UIElement.cpp
+++ b/src/ui/src/UIElement.cpp
@@ -131,16 +131,15 @@ void UIElement::Render(Drift::RHI::IUIBatcher& batch)
 
     // Só renderiza se tiver tamanho > 0
     if (m_Size.x > 0 && m_Size.y > 0) {
-        glm::vec2 absPos = GetAbsolutePosition();
         unsigned color = GetRenderColor();
-        
+
         // Aplica opacidade
         unsigned alpha = static_cast<unsigned>(((color >> 24) & 0xFF) * m_Opacity);
         color = (color & 0x00FFFFFF) | (alpha << 24);
-        
+
         // Só renderiza se o alpha final for > 0
         if (alpha > 0) {
-            batch.AddRect(absPos.x, absPos.y, m_Size.x, m_Size.y, color);
+            batch.AddQuad(m_WorldTransform, m_Size.x, m_Size.y, color);
         }
     }
 

--- a/src/ui/src/Widgets/Panel.cpp
+++ b/src/ui/src/Widgets/Panel.cpp
@@ -1,5 +1,6 @@
 #include "Drift/UI/Widgets/Panel.h"
 #include "Drift/RHI/Buffer.h"
+#include <glm/gtc/matrix_transform.hpp>
 
 using namespace Drift::UI;
 
@@ -26,7 +27,6 @@ void Panel::Render(Drift::RHI::IUIBatcher& batch)
 
     // Só renderiza se tiver tamanho > 0
     if (GetSize().x > 0 && GetSize().y > 0) {
-        glm::vec2 absPos = GetAbsolutePosition();
         unsigned color = GetRenderColor();
         
         // Aplica opacidade
@@ -35,7 +35,7 @@ void Panel::Render(Drift::RHI::IUIBatcher& batch)
         
         // Só renderiza se o alpha final for > 0
         if (alpha > 0) {
-            batch.AddRect(absPos.x, absPos.y, GetSize().x, GetSize().y, color);
+            batch.AddQuad(GetWorldTransform(), GetSize().x, GetSize().y, color);
         }
         
         // Renderiza borda se necessário
@@ -46,8 +46,6 @@ void Panel::Render(Drift::RHI::IUIBatcher& batch)
             // Só renderiza bordas se o alpha for > 0
             if (borderAlpha > 0) {
                 // Bordas simples (pode ser melhorado com linhas)
-                float x = absPos.x;
-                float y = absPos.y;
                 float w = GetSize().x;
                 float h = GetSize().y;
                 
@@ -66,14 +64,21 @@ void Panel::Render(Drift::RHI::IUIBatcher& batch)
                     // Garante um mínimo de 1 pixel
                     borderThickness = std::max(1.0f, borderThickness);
                     
+                    glm::mat4 base = GetWorldTransform();
+                    using glm::translate;
+                    glm::mat4 m;
                     // Borda superior
-                    batch.AddRect(x, y, w, borderThickness, borderColor);
+                    m = base * translate(glm::mat4(1.0f), {0.0f, 0.0f, 0.0f});
+                    batch.AddQuad(m, w, borderThickness, borderColor);
                     // Borda inferior
-                    batch.AddRect(x, y + h - borderThickness, w, borderThickness, borderColor);
+                    m = base * translate(glm::mat4(1.0f), {0.0f, h - borderThickness, 0.0f});
+                    batch.AddQuad(m, w, borderThickness, borderColor);
                     // Borda esquerda
-                    batch.AddRect(x, y, borderThickness, h, borderColor);
+                    m = base * translate(glm::mat4(1.0f), {0.0f, 0.0f, 0.0f});
+                    batch.AddQuad(m, borderThickness, h, borderColor);
                     // Borda direita
-                    batch.AddRect(x + w - borderThickness, y, borderThickness, h, borderColor);
+                    m = base * translate(glm::mat4(1.0f), {w - borderThickness, 0.0f, 0.0f});
+                    batch.AddQuad(m, borderThickness, h, borderColor);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- extend `IUIBatcher` with `AddQuad` helpers
- implement quad drawing in DX11 batcher
- render `UIElement` and `Panel` using world transform
- rotate the first button in `layout_test` to show transform

## Testing
- `cmake -S . -B build` *(fails: RandR headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883a24c450483258de785d11d519b18