### PR TITLE
Clamp child size in absolute layout

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -203,6 +203,22 @@ add_executable(LayoutPropagationTest
   app/layout_propagation_test.cpp
 )
 
+add_executable(AbsoluteLayoutClampTest
+  app/absolute_layout_clamp_test.cpp
+)
+
+target_include_directories(AbsoluteLayoutClampTest PUBLIC
+  core/include
+  engine/include
+  ui/include
+)
+
+target_link_libraries(AbsoluteLayoutClampTest PUBLIC
+  DriftCore
+  DriftEngine
+  DriftUI
+)
+
 add_executable(HitTestClippingTest
   app/hittest_clipping_test.cpp
 )

--- a/src/app/absolute_layout_clamp_test.cpp
+++ b/src/app/absolute_layout_clamp_test.cpp
@@ -1,0 +1,41 @@
+#include "Drift/UI/UIContext.h"
+#include "Drift/UI/Widgets/Panel.h"
+#include <memory>
+#include <iostream>
+
+using namespace Drift;
+
+int main() {
+    UI::UIContext ctx;
+    ctx.Initialize();
+    ctx.SetScreenSize(100.0f, 100.0f);
+
+    // Parent with absolute layout
+    auto parent = std::make_shared<UI::Panel>(&ctx);
+    UI::LayoutProperties parentLayout;
+    parentLayout.layoutType = UI::LayoutType::Absolute;
+    parent->SetLayoutProperties(parentLayout);
+    parent->SetSize({100.0f, 100.0f});
+    ctx.GetRoot()->AddChild(parent);
+
+    // Child stretched with excessive margins
+    auto child = std::make_shared<UI::Panel>(&ctx);
+    UI::LayoutProperties childLayout;
+    childLayout.horizontalAlign = UI::LayoutProperties::HorizontalAlign::Stretch;
+    childLayout.verticalAlign = UI::LayoutProperties::VerticalAlign::Stretch;
+    childLayout.margin = UI::LayoutMargins(80.0f).ToVec4();
+    child->SetLayoutProperties(childLayout);
+    child->SetSize({10.0f, 10.0f});
+    parent->AddChild(child);
+
+    ctx.Update(0.0f);
+
+    auto size = child->GetSize();
+    if (size.x < 0.0f || size.y < 0.0f) {
+        std::cerr << "Negative size after layout: " << size.x << ", " << size.y << std::endl;
+        return 1;
+    }
+
+    std::cout << "Absolute layout clamps negative sizes." << std::endl;
+    return 0;
+}

--- a/src/ui/src/LayoutEngine.cpp
+++ b/src/ui/src/LayoutEngine.cpp
@@ -173,12 +173,16 @@ void LayoutEngine::LayoutChildren(const std::vector<std::shared_ptr<UIElement>>&
                         // Aplica stretch horizontal se configurado
                         if (childProps.horizontalAlign == LayoutProperties::HorizontalAlign::Stretch) {
                             childSize.x = parentRect.width - childProps.margin.x - childProps.margin.z;
+                            // Garante que o tamanho não seja negativo
+                            if (childSize.x < 0) childSize.x = 0;
                             childPos.x = parentRect.x + childProps.margin.x;
                         }
-                        
+
                         // Aplica stretch vertical se configurado
                         if (childProps.verticalAlign == LayoutProperties::VerticalAlign::Stretch) {
                             childSize.y = parentRect.height - childProps.margin.y - childProps.margin.w;
+                            // Garante que o tamanho não seja negativo
+                            if (childSize.y < 0) childSize.y = 0;
                             childPos.y = parentRect.y + childProps.margin.y;
                         }
                         


### PR DESCRIPTION
## Summary
- clamp negative sizes in absolute-layout branch
- add regression test exercising the clamping
- build system: add new test executable

## Testing
- `cmake --build build` *(fails: GLM headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883a5734dd88325a38154cd0dfe58e7