### PR TITLE
Fix zero star weight in grid layout

### DIFF
--- a/src/ui/src/Widgets/Grid.cpp
+++ b/src/ui/src/Widgets/Grid.cpp
@@ -156,6 +156,7 @@ std::vector<float> Grid::CalculateGridSizes(const std::vector<GridUnit>& definit
     float fixedSize = 0.0f;
     float starWeight = 0.0f;
     int autoCount = 0;
+    int starCount = 0;
     
     for (const auto& def : definitions) {
         switch (def.type) {
@@ -169,6 +170,7 @@ std::vector<float> Grid::CalculateGridSizes(const std::vector<GridUnit>& definit
                 break;
             case GridUnitType::Star:
                 starWeight += def.value;
+                starCount++;
                 sizes.push_back(0.0f); // Placeholder
                 break;
         }
@@ -193,8 +195,12 @@ std::vector<float> Grid::CalculateGridSizes(const std::vector<GridUnit>& definit
             // Auto units get equal share of remaining space
             sizes[sizeIndex] = remainingSpace / autoCount;
         } else if (def.type == GridUnitType::Star) {
-            // Star units get proportional share
-            sizes[sizeIndex] = (def.value / starWeight) * remainingSpace;
+            // Star units get proportional share. Safeguard against zero weight.
+            if (starWeight == 0.0f && starCount > 0) {
+                sizes[sizeIndex] = remainingSpace / starCount;
+            } else {
+                sizes[sizeIndex] = (def.value / starWeight) * remainingSpace;
+            }
         }
         sizeIndex++;
     }


### PR DESCRIPTION
## Summary
- safeguard against zero star weights when computing grid cell sizes

## Testing
- `cmake -S . -B build` *(fails: RandR headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883ac5ccae0832589bfecaeab3cdca2