### PR TITLE
Fix optional test subdirectory in GLI

### DIFF
--- a/extern/gli/CMakeLists.txt
+++ b/extern/gli/CMakeLists.txt
@@ -72,7 +72,9 @@ endmacro(addExternalPackageGTC)
 # Add subdirectory
 
 add_subdirectory(gli)
-add_subdirectory(test)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test")
+    add_subdirectory(test)
+endif()
 #add_subdirectory(doc)
 
 ################################


### PR DESCRIPTION
## Summary
- fix test subdirectory detection in GLI's CMakeLists

## Testing
- `cmake ..`

------
https://chatgpt.com/codex/tasks/task_e_6883b1ac5d588325be9107e771a7d128