### PR TITLE
Fix Panel background color update

### DIFF
--- a/src/ui/include/Drift/UI/Widgets/Panel.h
+++ b/src/ui/include/Drift/UI/Widgets/Panel.h
@@ -15,6 +15,7 @@ public:
     {
         m_BackgroundColor = color;
         SetColor(color); // Keep the render color in sync
+        MarkDirty();
     }
     unsigned GetBackgroundColor() const { return m_BackgroundColor; }
     


### PR DESCRIPTION
## Summary
- mark `Panel` dirty when changing background color

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug` *(fails: `wrl/client.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b1ac44f48325825ddf8906a9785e