### PR TITLE
Clamp negative grid child sizes

### DIFF
--- a/src/ui/src/Widgets/Grid.cpp
+++ b/src/ui/src/Widgets/Grid.cpp
@@ -104,6 +104,10 @@ void Grid::RecalculateLayout() {
         float y = cellY + marginTop;
         float width = cellWidth - marginLeft - marginRight;
         float height = cellHeight - marginTop - marginBottom;
+
+        // Prevent negative sizes when margins exceed the cell size
+        width = std::max(width, 0.0f);
+        height = std::max(height, 0.0f);
         
         // Handle alignment
         if (childProps.horizontalAlign == LayoutProperties::HorizontalAlign::Center) {


### PR DESCRIPTION
## Summary
- clamp width and height in `Grid::RecalculateLayout` to avoid negative sizes when margins exceed cell dimensions

## Testing
- `cmake ..` *(fails: Xcursor/XInput headers etc. -> installed packages; build fails later due to missing GLM)*

------
https://chatgpt.com/codex/tasks/task_e_6883d6d75374832582ee5f9da310ef74