### PR TITLE
Introduce shared Color typedef

### DIFF
--- a/src/app/font_test.cpp
+++ b/src/app/font_test.cpp
@@ -12,6 +12,7 @@
 #include "Drift/RHI/DX11/SwapChainDX11.h"
 #include "Drift/RHI/DX11/UIBatcherDX11.h"
 #include "Drift/RHI/DX11/RingBufferDX11.h"
+#include "Drift/Core/Color.h"
 #include <GLFW/glfw3.h>
 #define GLFW_EXPOSE_NATIVE_WIN32
 #include <GLFW/glfw3native.h>
@@ -186,7 +187,7 @@ void TestFontSystem(UI::UIContext* uiContext)
     demoContainer->AddChild(colorDemoPanel);
     
     // Botões com diferentes cores
-    std::vector<std::pair<std::string, unsigned>> colorExamples = {
+    std::vector<std::pair<std::string, Drift::Color>> colorExamples = {
         {"Texto Branco", 0xFFFFFFFF},
         {"Texto Vermelho", 0xFFFF4444},
         {"Texto Verde", 0xFF44FF44},

--- a/src/app/layout_test.cpp
+++ b/src/app/layout_test.cpp
@@ -11,6 +11,7 @@
 #include "Drift/RHI/DX11/SwapChainDX11.h"
 #include "Drift/RHI/DX11/UIBatcherDX11.h"
 #include "Drift/RHI/DX11/RingBufferDX11.h"
+#include "Drift/Core/Color.h"
 #include <glm/glm.hpp>
 #include <GLFW/glfw3.h>
 #define GLFW_EXPOSE_NATIVE_WIN32
@@ -62,7 +63,7 @@ void TestLayoutSystem(UI::UIContext* uiContext)
         "Botão de Sair"
     };
     
-    std::vector<uint32_t> buttonColors = {
+    std::vector<Drift::Color> buttonColors = {
         0xFF4CAF50, // Verde
         0xFF2196F3, // Azul
         0xFFFF9800, // Laranja
@@ -78,7 +79,7 @@ void TestLayoutSystem(UI::UIContext* uiContext)
         button->SetNormalColor(buttonColors[i]);
         
         // Cores de hover e pressed calculadas de forma segura
-        uint32_t baseColor = buttonColors[i];
+        Drift::Color baseColor = buttonColors[i];
         
         // Extrai componentes RGB
         uint8_t r = (baseColor >> 16) & 0xFF;
@@ -89,13 +90,13 @@ void TestLayoutSystem(UI::UIContext* uiContext)
         uint8_t hoverR = (r + 40 > 255) ? 255 : r + 40;
         uint8_t hoverG = (g + 40 > 255) ? 255 : g + 40;
         uint8_t hoverB = (b + 40 > 255) ? 255 : b + 40;
-        uint32_t hoverColor = 0xFF000000 | (hoverR << 16) | (hoverG << 8) | hoverB;
+        Drift::Color hoverColor = 0xFF000000 | (hoverR << 16) | (hoverG << 8) | hoverB;
         
         // Calcula cores de pressed (mais escuras)
         uint8_t pressedR = (r < 40) ? 0 : r - 40;
         uint8_t pressedG = (g < 40) ? 0 : g - 40;
         uint8_t pressedB = (b < 40) ? 0 : b - 40;
-        uint32_t pressedColor = 0xFF000000 | (pressedR << 16) | (pressedG << 8) | pressedB;
+        Drift::Color pressedColor = 0xFF000000 | (pressedR << 16) | (pressedG << 8) | pressedB;
         
         button->SetHoverColor(hoverColor);
         button->SetPressedColor(pressedColor);

--- a/src/app/panel_color_test.cpp
+++ b/src/app/panel_color_test.cpp
@@ -1,5 +1,6 @@
 #include "Drift/UI/UIContext.h"
 #include "Drift/UI/Widgets/Panel.h"
+#include "Drift/Core/Color.h"
 #include <memory>
 #include <iostream>
 
@@ -10,7 +11,7 @@ int main() {
     ctx.Initialize();
 
     auto panel = std::make_shared<UI::Panel>(&ctx);
-    unsigned newColor = 0xFF123456;
+    Drift::Color newColor = 0xFF123456;
     panel->SetBackgroundColor(newColor);
 
     if (panel->GetRenderColor() != newColor) {

--- a/src/core/include/Drift/Core/Color.h
+++ b/src/core/include/Drift/Core/Color.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <cstdint>
+
+namespace Drift {
+    using Color = uint32_t;
+}
+

--- a/src/rhi/include/Drift/RHI/Buffer.h
+++ b/src/rhi/include/Drift/RHI/Buffer.h
@@ -5,6 +5,7 @@
 #include "Drift/RHI/Resource.h"
 #include <glm/mat4x4.hpp>
 #include <glm/vec4.hpp>
+#include "Drift/Core/Color.h"
 
 namespace Drift::RHI {
 
@@ -59,20 +60,20 @@ namespace Drift::RHI {
     public:
         virtual ~IUIBatcher() = default;
         virtual void Begin() = 0; // Inicia um novo batch
-        virtual void AddRect(float x, float y, float w, float h, unsigned color) = 0; // Adiciona retângulo
+        virtual void AddRect(float x, float y, float w, float h, Drift::Color color) = 0; // Adiciona retângulo
         virtual void AddQuad(float x0, float y0,
                              float x1, float y1,
                              float x2, float y2,
                              float x3, float y3,
-                             unsigned color) = 0; // Adiciona quad genérico
-        virtual void AddQuad(const glm::mat4& transform, float w, float h, unsigned color) {
+                             Drift::Color color) = 0; // Adiciona quad genérico
+        virtual void AddQuad(const glm::mat4& transform, float w, float h, Drift::Color color) {
             glm::vec4 p0 = transform * glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);
             glm::vec4 p1 = transform * glm::vec4(w, 0.0f, 0.0f, 1.0f);
             glm::vec4 p2 = transform * glm::vec4(w, h, 0.0f, 1.0f);
             glm::vec4 p3 = transform * glm::vec4(0.0f, h, 0.0f, 1.0f);
             AddQuad(p0.x, p0.y, p1.x, p1.y, p2.x, p2.y, p3.x, p3.y, color);
         }
-        virtual void AddText(float x, float y, const char* text, unsigned color) = 0;  // Adiciona texto
+        virtual void AddText(float x, float y, const char* text, Drift::Color color) = 0;  // Adiciona texto
         virtual void End() = 0;   // Finaliza e envia draw calls
 
         // Dimensões da tela (pode ser ignorado por implementações que usam matriz proj)

--- a/src/rhi_dx11/include/Drift/RHI/DX11/UIBatcherDX11.h
+++ b/src/rhi_dx11/include/Drift/RHI/DX11/UIBatcherDX11.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Drift/RHI/Buffer.h"
 #include "Drift/RHI/Context.h"
+#include "Drift/Core/Color.h"
 #include <vector>
 #include <memory>
 
@@ -26,11 +27,11 @@ class UIBatcherDX11 : public Drift::RHI::IUIBatcher {
 public:
     UIBatcherDX11(std::shared_ptr<IRingBuffer> ringBuffer, Drift::RHI::IContext* ctx);
     void Begin() override;
-    void AddRect(float x, float y, float w, float h, unsigned color) override;
+    void AddRect(float x, float y, float w, float h, Drift::Color color) override;
     void AddQuad(float x0, float y0, float x1, float y1,
                  float x2, float y2, float x3, float y3,
-                 unsigned color) override;
-    void AddText(float x, float y, const char* text, unsigned color) override;
+                 Drift::Color color) override;
+    void AddText(float x, float y, const char* text, Drift::Color color) override;
     void End() override;
 
     void SetScreenSize(float w, float h) override;
@@ -43,7 +44,7 @@ public:
 private:
     struct Vertex {
         float x, y;
-        unsigned color;
+        Drift::Color color;
     };
 
     // Helper

--- a/src/rhi_dx11/src/UIBatcherDX11.cpp
+++ b/src/rhi_dx11/src/UIBatcherDX11.cpp
@@ -11,7 +11,7 @@ using namespace Drift::RHI::DX11;
 using namespace Drift::RHI;
 
 // Conversão ARGB para BGRA otimizada (inline para performance)
-inline unsigned ConvertARGBtoBGRA(unsigned argb) {
+inline Drift::Color ConvertARGBtoBGRA(Drift::Color argb) {
     // ARGB: AAAA AAAA RRRR RRRR GGGG GGGG BBBB BBBB
     // BGRA: BBBB BBBB GGGG GGGG RRRR RRRR AAAA AAAA
     return ((argb & 0x000000FF) << 16) |  // B -> posição 16
@@ -45,7 +45,7 @@ void UIBatcherDX11::Begin() {
 }
 
 // Adiciona um retângulo ao batch de UI
-void UIBatcherDX11::AddRect(float x, float y, float w, float h, unsigned color) {
+void UIBatcherDX11::AddRect(float x, float y, float w, float h, Drift::Color color) {
     // Verifica se o retângulo está visível dentro do scissor atual
     ScissorRect currentScissor = GetCurrentScissorRect();
     if (currentScissor.IsValid()) {
@@ -69,7 +69,7 @@ void UIBatcherDX11::AddRect(float x, float y, float w, float h, unsigned color) 
     };
 
     // Conversão ARGB para BGRA otimizada
-    unsigned bgra = ConvertARGBtoBGRA(color);
+    Drift::Color bgra = ConvertARGBtoBGRA(color);
 
     unsigned base = (unsigned)_vertices.size();
     _vertices.push_back({toClipX(x),       toClipY(y),       bgra});
@@ -86,7 +86,7 @@ void UIBatcherDX11::AddRect(float x, float y, float w, float h, unsigned color) 
 
 void UIBatcherDX11::AddQuad(float x0, float y0, float x1, float y1,
                             float x2, float y2, float x3, float y3,
-                            unsigned color) {
+                            Drift::Color color) {
     ScissorRect currentScissor = GetCurrentScissorRect();
     if (currentScissor.IsValid()) {
         float minX = std::min({x0, x1, x2, x3});
@@ -102,7 +102,7 @@ void UIBatcherDX11::AddQuad(float x0, float y0, float x1, float y1,
     auto toClipX = [this](float px) { return (px / _screenW) * 2.0f - 1.0f; };
     auto toClipY = [this](float py) { return 1.0f - (py / _screenH) * 2.0f; };
 
-    unsigned bgra = ConvertARGBtoBGRA(color);
+    Drift::Color bgra = ConvertARGBtoBGRA(color);
     unsigned base = (unsigned)_vertices.size();
     _vertices.push_back({toClipX(x0), toClipY(y0), bgra});
     _vertices.push_back({toClipX(x1), toClipY(y1), bgra});
@@ -117,7 +117,7 @@ void UIBatcherDX11::AddQuad(float x0, float y0, float x1, float y1,
 }
 
 // Implementação do sistema de renderização de texto com MSDF
-void UIBatcherDX11::AddText(float x, float y, const char* text, unsigned color) {
+void UIBatcherDX11::AddText(float x, float y, const char* text, Drift::Color color) {
     if (!text || !_textRenderer) {
         return;
     }

--- a/src/ui/include/Drift/UI/FontSystem/TextRenderer.h
+++ b/src/ui/include/Drift/UI/FontSystem/TextRenderer.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <glm/glm.hpp>
 #include "Drift/RHI/Buffer.h"
+#include "Drift/Core/Color.h"
 #include "FontManager.h"
 
 namespace Drift::UI {
@@ -31,7 +32,7 @@ public:
                  const TextRenderSettings& settings = TextRenderSettings{});
     void AddText(const std::string& text, float x, float y,
                  const std::string& fontName = "default", float fontSize = 16.0f,
-                 unsigned color = 0xFFFFFFFF,
+                 Drift::Color color = 0xFFFFFFFF,
                  const TextRenderSettings& settings = TextRenderSettings{});
 
     void NextBatch();
@@ -63,7 +64,7 @@ public:
     explicit UIBatcherTextRenderer(Drift::RHI::IUIBatcher* batcher);
     ~UIBatcherTextRenderer();
 
-    void AddText(float x, float y, const char* text, unsigned color);
+    void AddText(float x, float y, const char* text, Drift::Color color);
     void AddText(const std::string& text, const glm::vec2& position,
                  const std::string& fontName, float fontSize,
                  const glm::vec4& color, const TextRenderSettings& settings);

--- a/src/ui/include/Drift/UI/UIElement.h
+++ b/src/ui/include/Drift/UI/UIElement.h
@@ -7,6 +7,7 @@
 #include <glm/vec2.hpp>
 #include <glm/mat4x4.hpp>
 #include "Drift/RHI/Buffer.h" // IUIBatcher
+#include "Drift/Core/Color.h"
 #include "Drift/UI/Transform2D.h"
 #include "Drift/UI/LayoutTypes.h"
 #include "Drift/Core/Log.h"
@@ -62,9 +63,9 @@ public:
     virtual void Render(Drift::RHI::IUIBatcher& batch);
 
     // === COR E ESTILO ===
-    void SetColor(unsigned col) { m_Color = col; }
-    unsigned GetColor() const { return m_Color; }
-    virtual unsigned GetRenderColor() const { return m_Color; }
+    void SetColor(Drift::Color col) { m_Color = col; }
+    Drift::Color GetColor() const { return m_Color; }
+    virtual Drift::Color GetRenderColor() const { return m_Color; }
 
     // === LAYOUT PROPERTIES ===
     void SetLayoutProperties(const LayoutProperties& props) { m_LayoutProps = props; MarkLayoutDirty(); }
@@ -118,7 +119,7 @@ protected:
     bool m_LayoutDirty{true};
     bool m_Visible{true};
     float m_Opacity{1.0f};
-    unsigned m_Color{0xFF00FFFF}; // ciano por padrão
+    Drift::Color m_Color{0xFF00FFFF}; // ciano por padrão
     
     // Layout
     LayoutProperties m_LayoutProps{};

--- a/src/ui/include/Drift/UI/Widgets/Button.h
+++ b/src/ui/include/Drift/UI/Widgets/Button.h
@@ -2,6 +2,7 @@
 
 #include "Drift/UI/UIElement.h"
 #include "Drift/Core/Log.h"
+#include "Drift/Core/Color.h"
 #include <functional>
 #include <string>
 #include <glm/vec2.hpp>
@@ -47,19 +48,19 @@ public:
     void SetOnHover(std::function<void(const ButtonHoverEvent&)> callback) { m_OnHover = callback; }
 
     // Estados visuais
-    void SetNormalColor(unsigned color) { 
+    void SetNormalColor(Drift::Color color) {
         m_NormalColor = color;
         UpdateState(); 
     }
-    void SetHoverColor(unsigned color) { 
+    void SetHoverColor(Drift::Color color) {
         m_HoverColor = color;
         UpdateState(); 
     }
-    void SetPressedColor(unsigned color) { 
+    void SetPressedColor(Drift::Color color) {
         m_PressedColor = color;
         UpdateState(); 
     }
-    void SetDisabledColor(unsigned color) { 
+    void SetDisabledColor(Drift::Color color) {
         m_DisabledColor = color;
         UpdateState(); 
     }
@@ -67,7 +68,7 @@ public:
     // Overrides
     void Update(float deltaSeconds) override;
     void Render(Drift::RHI::IUIBatcher& batch) override;
-    unsigned GetRenderColor() const override;
+    Drift::Color GetRenderColor() const override;
 
     // Eventos de mouse (override dos métodos virtuais da base)
     void OnMouseEnter() override;
@@ -77,7 +78,7 @@ public:
     void OnMouseClick(const glm::vec2& position) override;
 
     // Debug: Método público para verificar a cor atual
-    unsigned GetCurrentColor() const;
+    Drift::Color GetCurrentColor() const;
 
 private:
     void UpdateState();
@@ -94,19 +95,19 @@ private:
     std::function<void(const ButtonHoverEvent&)> m_OnHover;
 
     // Cores por estado (32 bits ARGB)
-    unsigned m_NormalColor{0xFF4A90E2};   // Azul
-    unsigned m_HoverColor{0xFF357ABD};    // Azul escuro
-    unsigned m_PressedColor{0xFF2E6DA4};  // Azul mais escuro
-    unsigned m_DisabledColor{0xFFCCCCCC}; // Cinza
+    Drift::Color m_NormalColor{0xFF4A90E2};   // Azul
+    Drift::Color m_HoverColor{0xFF357ABD};    // Azul escuro
+    Drift::Color m_PressedColor{0xFF2E6DA4};  // Azul mais escuro
+    Drift::Color m_DisabledColor{0xFFCCCCCC}; // Cinza
 
     // Constantes de cor comuns (ARGB format)
-    static constexpr unsigned COLOR_RED = 0xFFFF0000;
-    static constexpr unsigned COLOR_GREEN = 0xFF00FF00;
-    static constexpr unsigned COLOR_BLUE = 0xFF0000FF;
-    static constexpr unsigned COLOR_WHITE = 0xFFFFFFFF;
-    static constexpr unsigned COLOR_BLACK = 0xFF000000;
-    static constexpr unsigned COLOR_GRAY = 0xFF808080;
-    static constexpr unsigned COLOR_TRANSPARENT = 0x00000000;
+    static constexpr Drift::Color COLOR_RED = 0xFFFF0000;
+    static constexpr Drift::Color COLOR_GREEN = 0xFF00FF00;
+    static constexpr Drift::Color COLOR_BLUE = 0xFF0000FF;
+    static constexpr Drift::Color COLOR_WHITE = 0xFFFFFFFF;
+    static constexpr Drift::Color COLOR_BLACK = 0xFF000000;
+    static constexpr Drift::Color COLOR_GRAY = 0xFF808080;
+    static constexpr Drift::Color COLOR_TRANSPARENT = 0x00000000;
 };
 
 } // namespace Drift::UI 

--- a/src/ui/include/Drift/UI/Widgets/Image.h
+++ b/src/ui/include/Drift/UI/Widgets/Image.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Drift/UI/UIElement.h"
+#include "Drift/Core/Color.h"
 #include <string>
 #include <glm/vec4.hpp>
 
@@ -35,8 +36,8 @@ public:
     ScaleMode GetScaleMode() const { return m_ScaleMode; }
 
     // Tint color
-    void SetTintColor(unsigned color) { m_TintColor = color; }
-    unsigned GetTintColor() const { return m_TintColor; }
+    void SetTintColor(Drift::Color color) { m_TintColor = color; }
+    Drift::Color GetTintColor() const { return m_TintColor; }
 
     // Overrides
     void Update(float deltaSeconds) override;
@@ -50,7 +51,7 @@ private:
     glm::vec4 m_UV{0.0f, 0.0f, 1.0f, 1.0f}; // UV coordinates (x, y, width, height)
     glm::vec2 m_ImageSize{100.0f, 100.0f};   // Tamanho original da imagem
     ScaleMode m_ScaleMode{ScaleMode::Stretch};
-    unsigned m_TintColor{0xFFFFFFFF}; // Sem tint por padrão
+    Drift::Color m_TintColor{0xFFFFFFFF}; // Sem tint por padrão
 
     // TODO: Adicionar suporte a texturas quando implementarmos o sistema de recursos
     // std::shared_ptr<ITexture> m_Texture;

--- a/src/ui/include/Drift/UI/Widgets/Label.h
+++ b/src/ui/include/Drift/UI/Widgets/Label.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Drift/UI/UIElement.h"
+#include "Drift/Core/Color.h"
 #include <string>
 #include <glm/vec2.hpp>
 
@@ -33,8 +34,8 @@ public:
     TextAlign GetTextAlign() const { return m_TextAlign; }
 
     // Cor do texto
-    void SetTextColor(unsigned color) { m_TextColor = color; }
-    unsigned GetTextColor() const { return m_TextColor; }
+    void SetTextColor(Drift::Color color) { m_TextColor = color; }
+    Drift::Color GetTextColor() const { return m_TextColor; }
 
     // Overrides
     void Update(float deltaSeconds) override;
@@ -48,12 +49,12 @@ private:
     float m_FontSize{16.0f};
     std::string m_FontFamily{"Arial"};
     TextAlign m_TextAlign{TextAlign::Left};
-    unsigned m_TextColor{0xFFFFFFFF}; // Branco por padrão
+    Drift::Color m_TextColor{0xFFFFFFFF}; // Branco por padrão
 
     // Constantes de cor para texto
-    static constexpr unsigned COLOR_WHITE = 0xFFFFFFFF;
-    static constexpr unsigned COLOR_BLACK = 0xFF000000;
-    static constexpr unsigned COLOR_GRAY = 0xFF808080;
+    static constexpr Drift::Color COLOR_WHITE = 0xFFFFFFFF;
+    static constexpr Drift::Color COLOR_BLACK = 0xFF000000;
+    static constexpr Drift::Color COLOR_GRAY = 0xFF808080;
 };
 
 } // namespace Drift::UI 

--- a/src/ui/include/Drift/UI/Widgets/Panel.h
+++ b/src/ui/include/Drift/UI/Widgets/Panel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Drift/UI/UIElement.h"
+#include "Drift/Core/Color.h"
 #include <string>
 
 namespace Drift::UI {
@@ -11,16 +12,16 @@ public:
     ~Panel() override = default;
 
     // === PROPRIEDADES ESPECÍFICAS ===
-    void SetBackgroundColor(unsigned color)
+    void SetBackgroundColor(Drift::Color color)
     {
         m_BackgroundColor = color;
         SetColor(color); // Keep the render color in sync
         MarkDirty();
     }
-    unsigned GetBackgroundColor() const { return m_BackgroundColor; }
+    Drift::Color GetBackgroundColor() const { return m_BackgroundColor; }
     
-    void SetBorderColor(unsigned color) { m_BorderColor = color; }
-    unsigned GetBorderColor() const { return m_BorderColor; }
+    void SetBorderColor(Drift::Color color) { m_BorderColor = color; }
+    Drift::Color GetBorderColor() const { return m_BorderColor; }
     
     void SetBorderWidth(float width) { m_BorderWidth = width; }
     float GetBorderWidth() const { return m_BorderWidth; }
@@ -38,8 +39,8 @@ public:
     void Render(Drift::RHI::IUIBatcher& batch) override;
 
 private:
-    unsigned m_BackgroundColor{0xFF202020}; // Cinza escuro
-    unsigned m_BorderColor{0xFF404040};     // Cinza médio
+    Drift::Color m_BackgroundColor{0xFF202020}; // Cinza escuro
+    Drift::Color m_BorderColor{0xFF404040};     // Cinza médio
     float m_BorderWidth{1.0f};
     float m_CornerRadius{0.0f};
     bool m_ProportionalBorders{false};      // Bordas proporcionais

--- a/src/ui/src/FontSystem/TextRenderer.cpp
+++ b/src/ui/src/FontSystem/TextRenderer.cpp
@@ -75,9 +75,9 @@ void TextRenderer::AddText(const std::string& text, const glm::vec2& position,
     LOG_DEBUG("Added text command: '{}' at ({}, {})", text, position.x, position.y);
 }
 
-void TextRenderer::AddText(const std::string& text, float x, float y, 
-                          const std::string& fontName, float fontSize, 
-                          unsigned color, const TextRenderSettings& settings) {
+void TextRenderer::AddText(const std::string& text, float x, float y,
+                          const std::string& fontName, float fontSize,
+                          Drift::Color color, const TextRenderSettings& settings) {
     glm::vec4 colorVec;
     colorVec.r = static_cast<float>((color >> 16) & 0xFF) / 255.0f;
     colorVec.g = static_cast<float>((color >> 8) & 0xFF) / 255.0f;
@@ -178,7 +178,7 @@ UIBatcherTextRenderer::UIBatcherTextRenderer(Drift::RHI::IUIBatcher* batcher)
 
 UIBatcherTextRenderer::~UIBatcherTextRenderer() = default;
 
-void UIBatcherTextRenderer::AddText(float x, float y, const char* text, unsigned color) {
+void UIBatcherTextRenderer::AddText(float x, float y, const char* text, Drift::Color color) {
     if (!m_TextRenderer || !text) {
         return;
     }

--- a/src/ui/src/UIElement.cpp
+++ b/src/ui/src/UIElement.cpp
@@ -131,7 +131,7 @@ void UIElement::Render(Drift::RHI::IUIBatcher& batch)
 
     // Só renderiza se tiver tamanho > 0
     if (m_Size.x > 0 && m_Size.y > 0) {
-        unsigned color = GetRenderColor();
+        Drift::Color color = GetRenderColor();
 
         // Aplica opacidade
         unsigned alpha = static_cast<unsigned>(((color >> 24) & 0xFF) * m_Opacity);

--- a/src/ui/src/Widgets/Button.cpp
+++ b/src/ui/src/Widgets/Button.cpp
@@ -41,7 +41,7 @@ void Button::Render(Drift::RHI::IUIBatcher& batch)
         glm::vec2 textPos = absPos + size * 0.5f;
         
         // Renderiza o texto com a cor atual do botão
-        unsigned textColor = GetCurrentColor();
+        Drift::Color textColor = GetCurrentColor();
         batch.AddText(textPos.x, textPos.y, m_Text.c_str(), textColor);
     }
 }
@@ -118,9 +118,9 @@ void Button::UpdateState()
     }
 }
 
-unsigned Button::GetCurrentColor() const
+Drift::Color Button::GetCurrentColor() const
 {
-    unsigned color;
+    Drift::Color color;
     switch (m_CurrentState) {
         case ButtonState::Normal:
             color = m_NormalColor;
@@ -142,7 +142,7 @@ unsigned Button::GetCurrentColor() const
     return color;
 } 
 
-unsigned Button::GetRenderColor() const
+Drift::Color Button::GetRenderColor() const
 {
     return GetCurrentColor();
 } 

--- a/src/ui/src/Widgets/Grid.cpp
+++ b/src/ui/src/Widgets/Grid.cpp
@@ -216,7 +216,7 @@ void Grid::Render(Drift::RHI::IUIBatcher& batch)
     // Render background if we have a color
     if (GetRenderColor() != 0x00000000) {
         glm::vec2 absPos = GetAbsolutePosition();
-        unsigned color = GetRenderColor();
+        Drift::Color color = GetRenderColor();
         
         // Apply opacity
         unsigned alpha = static_cast<unsigned>(((color >> 24) & 0xFF) * GetOpacity());

--- a/src/ui/src/Widgets/Image.cpp
+++ b/src/ui/src/Widgets/Image.cpp
@@ -28,7 +28,7 @@ void Image::Render(Drift::RHI::IUIBatcher& batch)
         batch.AddRect(absPos.x, absPos.y, m_Size.x, m_Size.y, m_TintColor);
         
         // Renderiza uma borda para indicar que é uma imagem
-        unsigned borderColor = 0xFF888888;
+        Drift::Color borderColor = 0xFF888888;
         float borderWidth = 1.0f;
         
         // Borda superior
@@ -41,7 +41,7 @@ void Image::Render(Drift::RHI::IUIBatcher& batch)
         batch.AddRect(absPos.x + m_Size.x - borderWidth, absPos.y, borderWidth, m_Size.y, borderColor);
     } else {
         // Renderiza um placeholder se não há imagem
-        unsigned placeholderColor = 0xFF444444;
+        Drift::Color placeholderColor = 0xFF444444;
         batch.AddRect(absPos.x, absPos.y, m_Size.x, m_Size.y, placeholderColor);
     }
 

--- a/src/ui/src/Widgets/Panel.cpp
+++ b/src/ui/src/Widgets/Panel.cpp
@@ -27,7 +27,7 @@ void Panel::Render(Drift::RHI::IUIBatcher& batch)
 
     // Só renderiza se tiver tamanho > 0
     if (GetSize().x > 0 && GetSize().y > 0) {
-        unsigned color = GetRenderColor();
+        Drift::Color color = GetRenderColor();
         
         // Aplica opacidade
         unsigned alpha = static_cast<unsigned>(((color >> 24) & 0xFF) * GetOpacity());
@@ -41,7 +41,7 @@ void Panel::Render(Drift::RHI::IUIBatcher& batch)
         // Renderiza borda se necessário
         if (m_BorderWidth > 0.0f && m_BorderColor != 0) {
             unsigned borderAlpha = static_cast<unsigned>(((m_BorderColor >> 24) & 0xFF) * GetOpacity());
-            unsigned borderColor = (m_BorderColor & 0x00FFFFFF) | (borderAlpha << 24);
+            Drift::Color borderColor = (m_BorderColor & 0x00FFFFFF) | (borderAlpha << 24);
             
             // Só renderiza bordas se o alpha for > 0
             if (borderAlpha > 0) {

--- a/src/ui/src/Widgets/StackPanel.cpp
+++ b/src/ui/src/Widgets/StackPanel.cpp
@@ -156,7 +156,7 @@ void StackPanel::Render(Drift::RHI::IUIBatcher& batch)
     // Render background if we have a color
     if (GetRenderColor() != 0x00000000) {
         glm::vec2 absPos = GetAbsolutePosition();
-        unsigned color = GetRenderColor();
+        Drift::Color color = GetRenderColor();
         
         // Apply opacity
         unsigned alpha = static_cast<unsigned>(((color >> 24) & 0xFF) * GetOpacity());


### PR DESCRIPTION
## Summary
- create a common `Color` typedef
- use `Drift::Color` instead of `unsigned` for color parameters and members
- adjust widgets, batcher and apps to use the new type

## Testing
- `cmake ..` *(passes)*
- `cmake --build . --target PanelColorTest` *(fails: FontManager compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_6883d6d7a4b48325b1789e7ac3649f76