### PR TITLE
Implement texture data storage for FontAtlas

### DIFF
--- a/src/ui/include/Drift/UI/FontSystem/FontAtlas.h
+++ b/src/ui/include/Drift/UI/FontSystem/FontAtlas.h
@@ -49,6 +49,7 @@ private:
     AtlasConfig m_Config;
     std::unique_ptr<Drift::RHI::ITexture> m_Texture;
     std::shared_ptr<Drift::RHI::ITexture> m_SharedTexture; // Manter referência compartilhada
+    std::vector<uint8_t> m_TextureData;
     int m_Width{0};
     int m_Height{0};
     int m_CurrentX{0};


### PR DESCRIPTION
## Summary
- store CPU-side texture bytes in `FontAtlas`
- initialize vector and fill GPU texture with white pixels
- implement MSDF upload that writes to CPU buffer and GPU texture

## Testing
- `cmake ..`
- `cmake --build . --target DriftUI --config Release`


------
https://chatgpt.com/codex/tasks/task_e_68847f55be448325bb75a1492c177d8f