### PR TITLE
Add bounds check for MSDF uploads

### DIFF
--- a/src/ui/include/Drift/UI/FontSystem/FontAtlas.h
+++ b/src/ui/include/Drift/UI/FontSystem/FontAtlas.h
@@ -32,6 +32,9 @@ public:
     ~FontAtlas();
 
     AtlasRegion* AllocateRegion(int width, int height, uint32_t glyphId);
+
+    // Faz upload dos dados MSDF para o atlas. Retorna false se os dados excederem
+    // os limites do atlas ou se os parâmetros forem inválidos.
     bool UploadMSDFData(const AtlasRegion* region, const uint8_t* data, int width, int height);
     AtlasRegion* GetRegion(uint32_t glyphId) const;
     bool HasRegion(uint32_t glyphId) const;

--- a/src/ui/src/FontSystem/FontAtlas.cpp
+++ b/src/ui/src/FontSystem/FontAtlas.cpp
@@ -113,8 +113,15 @@ bool FontAtlas::UploadMSDFData(const AtlasRegion* region, const uint8_t* data, i
     // Copiar dados recebidos para o armazenamento CPU
     for (int row = 0; row < height; ++row) {
         size_t destOffset = static_cast<size_t>((region->y + row) * m_Width + region->x) * m_Config.channels;
-        size_t srcOffset = static_cast<size_t>(row * width * m_Config.channels);
-        std::copy_n(data + srcOffset, width * m_Config.channels, m_TextureData.begin() + destOffset);
+        size_t rowSize = static_cast<size_t>(width * m_Config.channels);
+        size_t endOffset = destOffset + rowSize;
+        if (endOffset > m_TextureData.size()) {
+            LOG_ERROR("MSDF upload exceeds atlas bounds");
+            return false;
+        }
+
+        size_t srcOffset = static_cast<size_t>(row * rowSize);
+        std::copy_n(data + srcOffset, rowSize, m_TextureData.begin() + destOffset);
     }
 
     size_t rowPitch = static_cast<size_t>(m_Width * m_Config.channels);


### PR DESCRIPTION
## Summary
- prevent out-of-bounds writes when uploading MSDF data
- document failure behaviour in `FontAtlas`
- propagate upload failures to callers

## Testing
- `cmake ..` *(fails: RandR headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884845cd96c8325928d158c9a680bf2