### PR TITLE
Add font metrics

### DIFF
--- a/src/ui/include/Drift/UI/FontSystem/Font.h
+++ b/src/ui/include/Drift/UI/FontSystem/Font.h
@@ -31,6 +31,8 @@ public:
 
     float GetSize() const { return m_Size; }
     const std::string& GetName() const { return m_Name; }
+    float GetAscent() const { return m_Ascent; }
+    float GetDescent() const { return m_Descent; }
 
 private:
     std::string m_Name;
@@ -38,6 +40,9 @@ private:
     FontQuality m_Quality;
     std::unordered_map<uint32_t, GlyphInfo> m_Glyphs;
     std::shared_ptr<Drift::RHI::ITexture> m_Texture;
+
+    float m_Ascent{0.0f};
+    float m_Descent{0.0f};
 };
 
 } // namespace Drift::UI

--- a/src/ui/src/FontSystem/Font.cpp
+++ b/src/ui/src/FontSystem/Font.cpp
@@ -6,7 +6,10 @@
 using namespace Drift::UI;
 
 Font::Font(std::string name, float size, FontQuality quality)
-    : m_Name(std::move(name)), m_Size(size), m_Quality(quality) {}
+    : m_Name(std::move(name)), m_Size(size), m_Quality(quality) {
+    m_Ascent = 0.0f;
+    m_Descent = 0.0f;
+}
 
 const GlyphInfo* Font::GetGlyph(uint32_t codepoint) const {
     auto it = m_Glyphs.find(codepoint);
@@ -48,6 +51,12 @@ bool Font::LoadFromMemory(const unsigned char* data, size_t size, Drift::RHI::ID
         Drift::Core::LogError("[Font] stbtt_InitFont falhou");
         return false;
     }
+
+    int ascent = 0, descent = 0, lineGap = 0;
+    stbtt_GetFontVMetrics(&info, &ascent, &descent, &lineGap);
+    float scale = stbtt_ScaleForPixelHeight(&info, m_Size);
+    m_Ascent = ascent * scale;
+    m_Descent = descent * scale;
     
     Drift::Core::LogRHIDebug("[Font] stb_truetype inicializado com sucesso");
 

--- a/src/ui/src/FontSystem/TextRenderer.cpp
+++ b/src/ui/src/FontSystem/TextRenderer.cpp
@@ -37,6 +37,7 @@ void TextRenderer::AddText(const std::string& text, const glm::vec2& pos,
     
     m_Batcher->SetTexture(0, const_cast<Drift::RHI::ITexture*>(texture));
 
+    float baseline = pos.y + font->GetAscent();
     float x = pos.x;
     for (char c : text) {
         const GlyphInfo* g = font->GetGlyph(static_cast<unsigned char>(c));
@@ -45,7 +46,7 @@ void TextRenderer::AddText(const std::string& text, const glm::vec2& pos,
         }
 
         float xpos = x + g->bearing.x;
-        float ypos = pos.y - g->bearing.y;
+        float ypos = baseline - g->bearing.y;
 
         glm::vec2 uv0 = g->uv0;
         glm::vec2 uv1 = g->uv1;
@@ -68,12 +69,11 @@ glm::vec2 TextRenderer::MeasureText(const std::string& text, const std::string& 
     if (!font) return glm::vec2(0.0f);
 
     float width = 0.0f;
-    float height = 0.0f;
+    float height = font->GetAscent() - font->GetDescent();
     for (char c : text) {
         const GlyphInfo* g = font->GetGlyph(static_cast<unsigned char>(c));
         if (!g) continue;
         width += g->advance;
-        height = std::max(height, g->size.y);
     }
     return glm::vec2(width, height);
 }


### PR DESCRIPTION
## Summary
- extend `Font` with ascent/descent metrics
- apply metrics when loading fonts
- offset glyphs from the baseline in `TextRenderer`
- compute measured height using the new metrics

## Testing
- `apt-get install -y libglm-dev`
- `g++ -std=c++17 -I./src -Isrc/core/include -Isrc/ui/include -Isrc/rhi/include test_font_loading.cpp -include fstream -o test_font_loading` *(fails: undefined reference to some symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68853449c1d08325bcbdec82f502eecb