### PR TITLE
Maintain separate batches for textured geometry

### DIFF
--- a/src/rhi_dx11/src/UIBatcherDX11.cpp
+++ b/src/rhi_dx11/src/UIBatcherDX11.cpp
@@ -153,7 +153,13 @@ void UIBatcherDX11::AddRect(float x, float y, float w, float h, Drift::Color col
         h = clippedRect.height;
     }
     
-    // Verificar se precisa fazer flush do batch
+    // Garantir que retângulos sólidos fiquem em um batch separado de geometrias texturizadas
+    if (m_CurrentBatch.hasTexture) {
+        FlushCurrentBatch();
+        m_CurrentBatch.hasTexture = false;
+    }
+
+    // Verificar se precisa fazer flush do batch por limite de vértices/índices
     if (m_CurrentBatch.vertexCount + 4 > m_BatchConfig.maxVertices ||
         m_CurrentBatch.indexCount + 6 > m_BatchConfig.maxIndices) {
         FlushCurrentBatch();
@@ -205,7 +211,13 @@ void UIBatcherDX11::AddQuad(float x0, float y0, float x1, float y1,
         }
     }
     
-    // Verificar se precisa fazer flush do batch
+    // Garantir que quads sólidos fiquem em um batch separado de geometrias texturizadas
+    if (m_CurrentBatch.hasTexture) {
+        FlushCurrentBatch();
+        m_CurrentBatch.hasTexture = false;
+    }
+
+    // Verificar se precisa fazer flush do batch por limite de vértices/índices
     if (m_CurrentBatch.vertexCount + 4 > m_BatchConfig.maxVertices ||
         m_CurrentBatch.indexCount + 6 > m_BatchConfig.maxIndices) {
         FlushCurrentBatch();


### PR DESCRIPTION
## Summary
- flush the active batch when switching from textured to solid geometry
- apply this logic in `AddRect` and `AddQuad`

## Testing
- `cmake ..`
- `cmake --build .` *(fails: fatal error: d3d11.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688534488fd883258594419b3f153c85