### PR TITLE
Add text rendering pipeline in DX11 batcher

### DIFF
--- a/src/rhi/include/Drift/RHI/UIBatcher.h
+++ b/src/rhi/include/Drift/RHI/UIBatcher.h
@@ -18,10 +18,19 @@ struct UIVertex {
     float u, v;           // Coordenadas UV (para texturas)
     Drift::Color color;   // Cor RGBA
     uint32_t textureId;   // ID da textura (0 = sem textura)
-    
-    UIVertex() : x(0), y(0), u(0), v(0), color(0xFFFFFFFF), textureId(0) {}
-    UIVertex(float x, float y, float u, float v, Drift::Color color, uint32_t textureId = 0)
-        : x(x), y(y), u(u), v(v), color(color), textureId(textureId) {}
+    float offsetX, offsetY; // Offset adicional para texto
+    float scale;            // Escala para texto
+    float rotation;         // Rotação para texto
+
+    UIVertex()
+        : x(0), y(0), u(0), v(0), color(0xFFFFFFFF), textureId(0),
+          offsetX(0.0f), offsetY(0.0f), scale(1.0f), rotation(0.0f) {}
+    UIVertex(float x, float y, float u, float v, Drift::Color color,
+             uint32_t textureId = 0,
+             float offsetX = 0.0f, float offsetY = 0.0f,
+             float scale = 1.0f, float rotation = 0.0f)
+        : x(x), y(y), u(u), v(v), color(color), textureId(textureId),
+          offsetX(offsetX), offsetY(offsetY), scale(scale), rotation(rotation) {}
 };
 
 // Configurações de batching

--- a/src/rhi_dx11/include/Drift/RHI/DX11/UIBatcherDX11.h
+++ b/src/rhi_dx11/include/Drift/RHI/DX11/UIBatcherDX11.h
@@ -33,16 +33,18 @@ struct UIBatch {
     std::vector<uint32_t> indices;
     uint32_t textureId;
     bool hasTexture;
+    bool isText;
     size_t vertexCount;
     size_t indexCount;
     
-    UIBatch() : textureId(0), hasTexture(false), vertexCount(0), indexCount(0) {}
+    UIBatch() : textureId(0), hasTexture(false), isText(false), vertexCount(0), indexCount(0) {}
     
     void Clear() {
         vertices.clear();
         indices.clear();
         textureId = 0;
         hasTexture = false;
+        isText = false;
         vertexCount = 0;
         indexCount = 0;
     }
@@ -138,6 +140,8 @@ private:
     // === Sistema de renderização de texto ===
     std::unique_ptr<Drift::UI::UIBatcherTextRenderer> m_TextRenderer;
     std::shared_ptr<ISampler> m_DefaultSampler;
+    std::shared_ptr<IBuffer> m_TextCB;
+    bool m_AddingText{false};
     
     // === Otimizações ===
     std::vector<UIVertex> m_VertexBuffer;

--- a/src/rhi_dx11/src/UIBatcherDX11.cpp
+++ b/src/rhi_dx11/src/UIBatcherDX11.cpp
@@ -8,9 +8,11 @@
 #include "Drift/RHI/DX11/DeviceDX11.h"
 #include "Drift/RHI/DX11/SamplerDX11.h"
 #include "Drift/RHI/Texture.h"
+#include "Drift/RHI/Buffer.h"
 #include "Drift/UI/FontSystem/TextRenderer.h"
 #include "Drift/UI/FontSystem/FontSystem.h"
 #include <glm/vec2.hpp>
+#include <glm/mat4x4.hpp>
 #include <cstring>
 #include <algorithm>
 #include <wrl/client.h>
@@ -18,6 +20,17 @@
 
 using namespace Drift::RHI::DX11;
 using namespace Drift::RHI;
+
+struct TextConstants {
+    glm::mat4 viewProjection{1.0f};
+    glm::vec2 screenSize{0.0f};
+    glm::vec2 atlasSize{0.0f};
+    float msdfRange{4.0f};
+    float smoothing{1.0f};
+    float contrast{1.0f};
+    float gamma{2.2f};
+    float padding[2]{0.0f, 0.0f};
+};
 
 // Conversão ARGB para BGRA otimizada (inline para performance)
 inline Drift::Color ConvertARGBtoBGRA(Drift::Color argb) {
@@ -74,6 +87,17 @@ UIBatcherDX11::UIBatcherDX11(std::shared_ptr<IRingBuffer> ringBuffer, IContext* 
     // Criar pipelines
     EnsurePipeline();
     CreateTextPipeline();
+
+    // Buffer de constantes para texto
+    auto* ctxDX11 = static_cast<ContextDX11*>(ctx);
+    if (ctxDX11) {
+        auto* device = static_cast<ID3D11Device*>(ctxDX11->GetNativeDevice());
+        auto* devCtx = ctxDX11->GetDeviceContext();
+        if (device && devCtx) {
+            BufferDesc cbd{ BufferType::Constant, sizeof(TextConstants), nullptr };
+            m_TextCB = CreateBufferDX11(device, devCtx, cbd);
+        }
+    }
     
     Core::Log("[UIBatcherDX11] Inicializado com sucesso");
 }
@@ -114,6 +138,17 @@ void UIBatcherDX11::Begin() {
     // Iniciar renderização de texto
     if (m_TextRenderer) {
         m_TextRenderer->BeginTextRendering();
+    }
+
+    // Atualizar constantes de texto
+    if (m_TextCB) {
+        TextConstants tc;
+        tc.screenSize = glm::vec2(m_ScreenW, m_ScreenH);
+        auto* ctxDX11 = static_cast<ContextDX11*>(m_Context);
+        if (ctxDX11) {
+            ctxDX11->UpdateConstantBuffer(static_cast<ID3D11Buffer*>(m_TextCB->GetBackendHandle()),
+                                        &tc, sizeof(TextConstants), 0);
+        }
     }
 }
 
@@ -170,10 +205,14 @@ void UIBatcherDX11::AddRect(float x, float y, float w, float h, Drift::Color col
     float clipX1 = ToClipX(x + w);
     float clipY1 = ToClipY(y + h);
     
-    m_CurrentBatch.vertices.emplace_back(clipX0, clipY0, 0.0f, 0.0f, bgra, 0);
-    m_CurrentBatch.vertices.emplace_back(clipX1, clipY0, 1.0f, 0.0f, bgra, 0);
-    m_CurrentBatch.vertices.emplace_back(clipX1, clipY1, 1.0f, 1.0f, bgra, 0);
-    m_CurrentBatch.vertices.emplace_back(clipX0, clipY1, 0.0f, 1.0f, bgra, 0);
+    m_CurrentBatch.vertices.emplace_back(clipX0, clipY0, 0.0f, 0.0f, bgra, 0,
+                                        0.0f, 0.0f, 1.0f, 0.0f);
+    m_CurrentBatch.vertices.emplace_back(clipX1, clipY0, 1.0f, 0.0f, bgra, 0,
+                                        0.0f, 0.0f, 1.0f, 0.0f);
+    m_CurrentBatch.vertices.emplace_back(clipX1, clipY1, 1.0f, 1.0f, bgra, 0,
+                                        0.0f, 0.0f, 1.0f, 0.0f);
+    m_CurrentBatch.vertices.emplace_back(clipX0, clipY1, 0.0f, 1.0f, bgra, 0,
+                                        0.0f, 0.0f, 1.0f, 0.0f);
     
     // Adicionar índices
     m_CurrentBatch.indices.push_back(baseIndex + 0);
@@ -217,10 +256,14 @@ void UIBatcherDX11::AddQuad(float x0, float y0, float x1, float y1,
     // Adicionar vértices
     uint32_t baseIndex = static_cast<uint32_t>(m_CurrentBatch.vertices.size());
     
-    m_CurrentBatch.vertices.emplace_back(ToClipX(x0), ToClipY(y0), 0.0f, 0.0f, bgra, 0);
-    m_CurrentBatch.vertices.emplace_back(ToClipX(x1), ToClipY(y1), 1.0f, 0.0f, bgra, 0);
-    m_CurrentBatch.vertices.emplace_back(ToClipX(x2), ToClipY(y2), 1.0f, 1.0f, bgra, 0);
-    m_CurrentBatch.vertices.emplace_back(ToClipX(x3), ToClipY(y3), 0.0f, 1.0f, bgra, 0);
+    m_CurrentBatch.vertices.emplace_back(ToClipX(x0), ToClipY(y0), 0.0f, 0.0f, bgra, 0,
+                                        0.0f, 0.0f, 1.0f, 0.0f);
+    m_CurrentBatch.vertices.emplace_back(ToClipX(x1), ToClipY(y1), 1.0f, 0.0f, bgra, 0,
+                                        0.0f, 0.0f, 1.0f, 0.0f);
+    m_CurrentBatch.vertices.emplace_back(ToClipX(x2), ToClipY(y2), 1.0f, 1.0f, bgra, 0,
+                                        0.0f, 0.0f, 1.0f, 0.0f);
+    m_CurrentBatch.vertices.emplace_back(ToClipX(x3), ToClipY(y3), 0.0f, 1.0f, bgra, 0,
+                                        0.0f, 0.0f, 1.0f, 0.0f);
     
     // Adicionar índices
     m_CurrentBatch.indices.push_back(baseIndex + 0);
@@ -258,14 +301,19 @@ void UIBatcherDX11::AddTexturedRect(float x, float y, float w, float h,
 
     m_CurrentBatch.textureId = textureId;
     m_CurrentBatch.hasTexture = true;
+    if (m_AddingText) m_CurrentBatch.isText = true;
 
     Drift::Color bgra = ConvertARGBtoBGRA(color);
 
     uint32_t baseIndex = static_cast<uint32_t>(m_CurrentBatch.vertices.size());
-    m_CurrentBatch.vertices.emplace_back(ToClipX(x), ToClipY(y), uvMin.x, uvMin.y, bgra, textureId);
-    m_CurrentBatch.vertices.emplace_back(ToClipX(x + w), ToClipY(y), uvMax.x, uvMin.y, bgra, textureId);
-    m_CurrentBatch.vertices.emplace_back(ToClipX(x + w), ToClipY(y + h), uvMax.x, uvMax.y, bgra, textureId);
-    m_CurrentBatch.vertices.emplace_back(ToClipX(x), ToClipY(y + h), uvMin.x, uvMax.y, bgra, textureId);
+    m_CurrentBatch.vertices.emplace_back(ToClipX(x), ToClipY(y), uvMin.x, uvMin.y, bgra, textureId,
+                                        0.0f, 0.0f, 1.0f, 0.0f);
+    m_CurrentBatch.vertices.emplace_back(ToClipX(x + w), ToClipY(y), uvMax.x, uvMin.y, bgra, textureId,
+                                        0.0f, 0.0f, 1.0f, 0.0f);
+    m_CurrentBatch.vertices.emplace_back(ToClipX(x + w), ToClipY(y + h), uvMax.x, uvMax.y, bgra, textureId,
+                                        0.0f, 0.0f, 1.0f, 0.0f);
+    m_CurrentBatch.vertices.emplace_back(ToClipX(x), ToClipY(y + h), uvMin.x, uvMax.y, bgra, textureId,
+                                        0.0f, 0.0f, 1.0f, 0.0f);
 
     m_CurrentBatch.indices.push_back(baseIndex + 0);
     m_CurrentBatch.indices.push_back(baseIndex + 1);
@@ -280,16 +328,22 @@ void UIBatcherDX11::AddTexturedRect(float x, float y, float w, float h,
 }
 
 void UIBatcherDX11::AddText(float x, float y, const char* text, Drift::Color color) {
-    
+
     if (m_TextRenderer) {
+        if (!m_CurrentBatch.IsEmpty()) {
+            FlushCurrentBatch();
+        }
+        m_AddingText = true;
         // Converter Drift::Color para glm::vec4
         float r = static_cast<float>((color >> 16) & 0xFF) / 255.0f;
         float g = static_cast<float>((color >> 8) & 0xFF) / 255.0f;
         float b = static_cast<float>(color & 0xFF) / 255.0f;
         float a = static_cast<float>((color >> 24) & 0xFF) / 255.0f;
         glm::vec4 textColor(r, g, b, a);
-        
+
         m_TextRenderer->AddText(std::string(text), glm::vec2(x, y), "default", 16.0f, textColor);
+        FlushCurrentBatch();
+        m_AddingText = false;
     } else {
         Core::Log("[UIBatcherDX11] ERRO: m_TextRenderer é nullptr!");
     }
@@ -443,7 +497,47 @@ void UIBatcherDX11::EnsurePipeline() {
 }
 
 void UIBatcherDX11::CreateTextPipeline() {
-    m_TextPipeline = m_Pipeline; // Por enquanto, usar o mesmo pipeline
+    if (m_TextPipeline) {
+        return;
+    }
+
+    PipelineDesc textDesc;
+    textDesc.vsFile = "shaders/TextVS.hlsl";
+    textDesc.vsEntry = "main";
+    textDesc.psFile = "shaders/TextPS.hlsl";
+    textDesc.psEntry = "main";
+
+    textDesc.inputLayout = {
+        {"POSITION", 0, VertexFormat::R32G32_FLOAT, offsetof(UIVertex, x)},
+        {"TEXCOORD", 0, VertexFormat::R32G32_FLOAT, offsetof(UIVertex, u)},
+        {"COLOR", 0, VertexFormat::R8G8B8A8_UNORM, offsetof(UIVertex, color)},
+        {"TEXCOORD", 1, VertexFormat::R32G32_FLOAT, offsetof(UIVertex, offsetX)},
+        {"TEXCOORD", 2, VertexFormat::R32_FLOAT, offsetof(UIVertex, scale)},
+        {"TEXCOORD", 3, VertexFormat::R32_FLOAT, offsetof(UIVertex, rotation)}
+    };
+
+    textDesc.blend.enable = true;
+    textDesc.blend.srcColor = PipelineDesc::BlendDesc::BlendFactor::SrcAlpha;
+    textDesc.blend.dstColor = PipelineDesc::BlendDesc::BlendFactor::InvSrcAlpha;
+    textDesc.blend.colorOp = PipelineDesc::BlendDesc::BlendOp::Add;
+    textDesc.blend.srcAlpha = PipelineDesc::BlendDesc::BlendFactor::One;
+    textDesc.blend.dstAlpha = PipelineDesc::BlendDesc::BlendFactor::InvSrcAlpha;
+    textDesc.blend.alphaOp = PipelineDesc::BlendDesc::BlendOp::Add;
+    textDesc.blend.blendFactorSeparate = true;
+
+    textDesc.depthStencil.depthEnable = false;
+    textDesc.depthStencil.depthWrite = false;
+
+    auto* contextDX11 = static_cast<ContextDX11*>(m_Context);
+    if (contextDX11) {
+        auto* device = static_cast<ID3D11Device*>(contextDX11->GetNativeDevice());
+        if (device) {
+            m_TextPipeline = CreatePipelineDX11(device, textDesc);
+            if (!m_TextPipeline) {
+                Core::Log("[UIBatcherDX11] ERRO: Falha ao criar pipeline de texto!");
+            }
+        }
+    }
 }
 
 void UIBatcherDX11::FlushCurrentBatch() {
@@ -487,11 +581,15 @@ void UIBatcherDX11::RenderBatch(const UIBatch& batch) {
         return;
     }
     
-    // Configurar pipeline UI se necessário
+    // Configurar pipeline
     EnsureUIPipeline();
-    
-    // Aplicar pipeline UI
-    if (m_Pipeline) {
+    if (batch.isText && m_TextPipeline) {
+        m_TextPipeline->Apply(*contextDX11);
+        if (m_TextCB) {
+            contextDX11->VSSetConstantBuffer(0, m_TextCB->GetBackendHandle());
+            contextDX11->PSSetConstantBuffer(0, m_TextCB->GetBackendHandle());
+        }
+    } else if (m_Pipeline) {
         m_Pipeline->Apply(*contextDX11);
     } else {
         Core::Log("[UIBatcherDX11] ERRO: Pipeline UI é nullptr!");


### PR DESCRIPTION
## Summary
- extend `UIVertex` with text transform attributes
- create specialized text pipeline using `TextVS.hlsl`/`TextPS.hlsl`
- apply text pipeline when rendering text batches
- bind text constants and font texture before drawing text

## Testing
- `cmake ..` *(fails: XInput headers not found; install libxi development package)*
- `cmake --build .` *(fails: d3d11.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68853446e33c8325a744a141455ba149