### PR TITLE
Fix UI batcher shader without texture

### DIFF
--- a/shaders/UIBatch.hlsl
+++ b/shaders/UIBatch.hlsl
@@ -77,8 +77,8 @@ float4 PSMain(PSIn i) : SV_TARGET {
     // Cor já está em formato RGBA, usar diretamente
     float4 rgbaColor = i.col;
     
-    // Se tem textura (textureId < 16), usar a textura com a cor
-    if (i.textureId < 16) {
+    // Se tem textura (0-15) e não é o identificador especial 8 (sem textura)
+    if (i.textureId < 16 && i.textureId != 8) {
         float4 texColor = SampleTexture(i.textureId, i.uv);
         
         // Otimização: early-out para texturas completamente transparentes


### PR DESCRIPTION
## Summary
- avoid sampling textures when no texture is bound

## Testing
- `cmake ..` *(fails: RandR headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_68865fc6d23483258bfb8f8eb87136a2