### PR TITLE
Use default font name in DX11 batcher

### DIFF
--- a/src/rhi_dx11/src/UIBatcherDX11.cpp
+++ b/src/rhi_dx11/src/UIBatcherDX11.cpp
@@ -6,6 +6,7 @@
 #include "Drift/RHI/DX11/SamplerDX11.h"
 #include "Drift/RHI/DX11/BufferDX11.h"
 #include "Drift/UI/FontSystem/TextRenderer.h"
+#include "Drift/UI/FontSystem/FontManager.h"
 #include "Drift/Core/Log.h"
 #include <d3d11.h>
 #include <algorithm>
@@ -420,8 +421,12 @@ void UIBatcherDX11::OnAddText(float x, float y, const char* text, Drift::Color c
         Core::Log("[UIBatcherDX11] AVISO: Textura 0 não encontrada!");
     }
     
+    // Obter fonte padrão do FontManager
+    auto& fontManager = Drift::UI::FontManager::GetInstance();
+    const std::string& defaultFont = fontManager.GetDefaultFontName();
+
     // Renderizar texto usando o text renderer
-    m_TextRenderer->AddText(std::string(text), glm::vec2(x, y), "default", 16.0f, glm::vec4(1.0f, 1.0f, 1.0f, 1.0f));
+    m_TextRenderer->AddText(std::string(text), glm::vec2(x, y), defaultFont, 16.0f, glm::vec4(1.0f, 1.0f, 1.0f, 1.0f));
 }
 
 void UIBatcherDX11::OnBeginText() {

--- a/src/ui/include/Drift/UI/FontSystem/FontManager.h
+++ b/src/ui/include/Drift/UI/FontSystem/FontManager.h
@@ -39,6 +39,7 @@ public:
     void SetDefaultSize(float size) { m_DefaultSize = size; }
     void SetDefaultQuality(FontQuality q) { m_DefaultQuality = q; }
     void SetCacheConfig(const FontCacheConfig& config) { m_CacheConfig = config; }
+    const std::string& GetDefaultFontName() const { return m_DefaultFontName; }
 
     // Carregamento e obtenção de fontes
     std::shared_ptr<Font> LoadFont(const std::string& name, const std::string& path, float size, FontQuality quality);

--- a/src/ui/src/FontSystem/FontManager.cpp
+++ b/src/ui/src/FontSystem/FontManager.cpp
@@ -11,6 +11,10 @@ FontManager& FontManager::GetInstance() {
     return instance;
 }
 
+const std::string& FontManager::GetDefaultFontName() const {
+    return m_DefaultFontName;
+}
+
 size_t FontManager::GetCurrentTime() const {
     return std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now().time_since_epoch()


### PR DESCRIPTION
## Summary
- expose `FontManager::GetDefaultFontName`
- use the default font name when adding text in `UIBatcherDX11`

## Testing
- `cmake -B build2 -S .` *(fails: RandR headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_688672d92e708325bf0d4f691a73f4e4