### PR TITLE
Make default font path configurable

### DIFF
--- a/src/ui/include/Drift/UI/FontSystem/FontManager.h
+++ b/src/ui/include/Drift/UI/FontSystem/FontManager.h
@@ -36,10 +36,12 @@ public:
     // Configuração do sistema
     void SetDevice(Drift::RHI::IDevice* device) { m_Device = device; }
     void SetDefaultFontName(const std::string& name) { m_DefaultFontName = name; }
+    void SetDefaultFontPath(const std::string& path) { m_DefaultFontPath = path; }
     void SetDefaultSize(float size) { m_DefaultSize = size; }
     void SetDefaultQuality(FontQuality q) { m_DefaultQuality = q; }
     void SetCacheConfig(const FontCacheConfig& config) { m_CacheConfig = config; }
     const std::string& GetDefaultFontName() const { return m_DefaultFontName; }
+    const std::string& GetDefaultFontPath() const;
 
     // Carregamento e obtenção de fontes
     std::shared_ptr<Font> LoadFont(const std::string& name, const std::string& path, float size, FontQuality quality);
@@ -119,6 +121,7 @@ private:
     mutable std::mutex m_Mutex;
     Drift::RHI::IDevice* m_Device{nullptr};
     std::string m_DefaultFontName{"default"};
+    std::string m_DefaultFontPath{"fonts/Arial-Regular.ttf"};
     float m_DefaultSize{16.0f};
     FontQuality m_DefaultQuality{FontQuality::High};
     FontCacheConfig m_CacheConfig;

--- a/src/ui/src/FontSystem/FontManager.cpp
+++ b/src/ui/src/FontSystem/FontManager.cpp
@@ -15,6 +15,10 @@ const std::string& FontManager::GetDefaultFontName() const {
     return m_DefaultFontName;
 }
 
+const std::string& FontManager::GetDefaultFontPath() const {
+    return m_DefaultFontPath;
+}
+
 size_t FontManager::GetCurrentTime() const {
     return std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now().time_since_epoch()

--- a/src/ui/src/FontSystem/TextRenderer.cpp
+++ b/src/ui/src/FontSystem/TextRenderer.cpp
@@ -37,7 +37,7 @@ void TextRenderer::AddText(const std::string& text, const glm::vec2& pos,
     }
     if (!font) {
         // Tentar carregar a fonte se não encontrada
-        font = fm.GetOrLoadFont(fontName, "fonts/Arial-Regular.ttf", fontSize, UI::FontQuality::High);
+        font = fm.GetOrLoadFont(fontName, fm.GetDefaultFontPath(), fontSize, UI::FontQuality::High);
         if (!font) {
             Drift::Core::LogError("[TextRenderer] Falha no carregamento da fonte");
             return;

--- a/src/ui/src/UIContext.cpp
+++ b/src/ui/src/UIContext.cpp
@@ -133,6 +133,7 @@ void UIContext::InitializeFontSystem()
     
     // Configurar fonte padrão
     fontManager.SetDefaultFontName("default");
+    fontManager.SetDefaultFontPath(ResolveFontPath("fonts/Arial-Regular.ttf"));
     fontManager.SetDefaultSize(16.0f);
     fontManager.SetDefaultQuality(UI::FontQuality::High);
     
@@ -175,8 +176,8 @@ void UIContext::LoadFonts()
     
     auto& fontManager = UI::FontManager::GetInstance();
     
-    // Resolver caminho da fonte
-    std::string fontPath = ResolveFontPath("fonts/Arial-Regular.ttf");
+    // Obter caminho da fonte padrão
+    std::string fontPath = fontManager.GetDefaultFontPath();
     Drift::Core::LogRHI("[UIContext] Caminho da fonte resolvido: " + fontPath);
     
     // Pré-carregar o arquivo TTF uma única vez


### PR DESCRIPTION
## Summary
- expose a configurable default font path in `FontManager`
- use the default font path when loading missing fonts in `TextRenderer`
- set and query the default font path from `UIContext`

## Testing
- `cmake ..` *(fails: Doxygen missing but config generated)*
- `make -j2` *(fails: fatal error: d3d11.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688674823ab88325bbbf3f678dd43382