### PR TITLE
Fix namespaces and update log macros

### DIFF
--- a/src/core/include/Drift/Core/Assets/AssetsSystem.h
+++ b/src/core/include/Drift/Core/Assets/AssetsSystem.h
@@ -10,6 +10,7 @@
 #include <typeindex>
 #include <vector>
 #include <chrono>
+#include <iomanip>
 #include <any>
 #include <future>
 #include <queue>
@@ -597,4 +598,5 @@ void AssetsSystem::LoadAssetAsyncInternal(const AssetKey& key, const std::any& p
 #define DRIFT_PRELOAD_ASSET(type, path) \
     DRIFT_ASSETS().PreloadAsset<type>(path)
 
-} // namespace Drift::Core::Assets 
+} // namespace Drift::Core::Assets
+

--- a/src/core/include/Drift/Core/Log.h
+++ b/src/core/include/Drift/Core/Log.h
@@ -109,8 +109,6 @@ private:
     
     std::string FormatLogMessage(LogLevel level, const char* file, int line, const char* function, const std::string& message);
     std::string GetLevelString(LogLevel level);
-    // Função utilitária global para timestamp
-    std::string GetTimestamp();
     std::string GetThreadInfo();
     std::string GetFileInfo(const char* file, int line, const char* function);
     
@@ -136,6 +134,9 @@ inline void LogRHIError(const std::string& msg) { g_LogSystem.LogRHIError(msg); 
 inline void LogRHIDebug(const std::string& msg) { g_LogSystem.LogRHIDebug(msg); }
 inline void LogException(const std::string& context, const std::exception& e) { g_LogSystem.LogException(context, e); }
 inline void LogHRESULT(const std::string& context, HRESULT hr) { g_LogSystem.LogHRESULT(context, hr); }
+
+// Função utilitária global para timestamp
+std::string GetTimestamp();
 
 } // namespace Drift::Core
 
@@ -200,3 +201,5 @@ inline void LogHRESULT(const std::string& context, HRESULT hr) { g_LogSystem.Log
 // Macros para logging de memória
 #define LOG_MEM(msg) LOG_DEBUG("[MEM] " << msg)
 #define LOG_MEM_IF(condition, msg) LOG_DEBUG_IF(condition, "[MEM] " << msg)
+
+} // namespace Drift

--- a/src/core/include/Drift/Core/Profiler.h
+++ b/src/core/include/Drift/Core/Profiler.h
@@ -237,4 +237,6 @@ private:
 #define PROFILE_UPDATE(name) PROFILE_SCOPE("[UPDATE]" name)
 #define PROFILE_LOAD(name) PROFILE_SCOPE("[LOAD]" name)
 
-} // namespace Drift::Core 
+} // namespace Drift::Core
+
+

--- a/src/core/include/Drift/Core/Threading/ThreadingSystem.h
+++ b/src/core/include/Drift/Core/Threading/ThreadingSystem.h
@@ -306,4 +306,4 @@ auto ThreadingSystem::SubmitWithInfo(const TaskInfo& info, F&& f, Args&&... args
 // Macros para sincronização
 #define DRIFT_WAIT_FOR_ALL() Drift::Core::Threading::ThreadingSystem::GetInstance().WaitForAll()
 
-} // namespace Drift::Core::Threading 
+} // namespace Drift::Core::Threading

--- a/src/core/src/Assets/AssetsExample.cpp
+++ b/src/core/src/Assets/AssetsExample.cpp
@@ -146,7 +146,7 @@ void AssetsExample::RunAsyncLoadingExample() {
                 DRIFT_LOG_INFO("[AssetsExample] Asset ", i, " carregado: ", asset->GetName());
             }
         } catch (const std::exception& e) {
-            LOG_ERROR("[AssetsExample] Falha ao carregar asset {}: {}", i, e.what());
+            DRIFT_LOG_ERROR("[AssetsExample] Falha ao carregar asset {}: {}", i, e.what());
         }
     }
     
@@ -393,7 +393,7 @@ void AssetsExample::OnAssetUnloaded(const std::string& path, std::type_index typ
 }
 
 void AssetsExample::OnAssetFailed(const std::string& path, std::type_index type, const std::string& error) {
-    LOG_ERROR("[AssetsExample] Falha ao carregar asset: {} - {}", path, error);
+    DRIFT_LOG_ERROR("[AssetsExample] Falha ao carregar asset: {} - {}", path, error);
 }
 
 } // namespace Drift::Core::Assets 

--- a/src/core/src/Log.cpp
+++ b/src/core/src/Log.cpp
@@ -2,15 +2,24 @@
 #include <iostream>
 #include <sstream>
 #include <iomanip>
+#ifdef _WIN32
 #include <d3d11.h>
+#endif
 #include <filesystem>
 #include <thread>
 #include <algorithm>
 #include <chrono>
 #include <ctime>
 
+#ifndef _WIN32
+inline bool FAILED(long hr) { return hr < 0; }
+#endif
+
 namespace Drift {
 namespace Core {
+
+// Forward declaration of helper
+std::string GetTimestamp();
 // Implementação do ConsoleLogOutput
 void ConsoleLogOutput::Write(LogLevel level, const std::string& message) {
     std::cout << message << std::endl;
@@ -180,10 +189,11 @@ void LogSystem::LogException(const std::string& context, const std::exception& e
 }
 
 void LogSystem::LogHRESULT(const std::string& context, HRESULT hr) {
+#ifdef _WIN32
     if (FAILED(hr)) {
         std::stringstream ss;
         ss << "[HRESULT][" << context << "] 0x" << std::hex << std::setw(8) << std::setfill('0') << hr;
-        
+
         // Adicionar descrição comum do HRESULT
         switch (hr) {
             case E_INVALIDARG:
@@ -223,11 +233,16 @@ void LogSystem::LogHRESULT(const std::string& context, HRESULT hr) {
                 ss << " (HRESULT desconhecido)";
                 break;
         }
-        
+
         LogRHIError(ss.str());
     } else {
         LogRHIDebug("[HRESULT][" + context + "] Sucesso (0x" + std::to_string(hr) + ")");
     }
+#else
+    std::stringstream ss;
+    ss << "[HRESULT][" << context << "] 0x" << std::hex << std::setw(8) << std::setfill('0') << hr;
+    LogRHIError(ss.str());
+#endif
 }
 
 void LogSystem::Log(const std::string& message) {

--- a/src/core/src/LogProfilerExample.cpp
+++ b/src/core/src/LogProfilerExample.cpp
@@ -40,14 +40,14 @@ void DemonstrateLogging() {
     LOG_INFO_IF(!debugMode, "Debug mode está desativado");
     
     // Demonstração de logging de performance
-    LOG_PERF("Iniciando operação crítica");
+    DRIFT_LOG_DEBUG("[PERF] Iniciando operação crítica");
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    LOG_PERF("Operação crítica concluída");
+    DRIFT_LOG_DEBUG("[PERF] Operação crítica concluída");
     
     // Demonstração de logging de memória
-    LOG_MEM("Alocando 1024 bytes");
+    DRIFT_LOG_DEBUG("[MEM] Alocando 1024 bytes");
     std::vector<int> data(256);
-    LOG_MEM("Vetor alocado com {} elementos", data.size());
+    DRIFT_LOG_DEBUG("[MEM] Vetor alocado com {} elementos", data.size());
     
     // Demonstração de logging RHI
     LogRHI("Inicializando contexto DirectX 11");
@@ -62,8 +62,13 @@ void DemonstrateLogging() {
     }
     
     // Demonstração de logging de HRESULT
+#ifdef _WIN32
     LogHRESULT("Criação de dispositivo", S_OK);
     LogHRESULT("Criação de buffer", E_INVALIDARG);
+#else
+    LogHRESULT("Criação de dispositivo", 0);
+    LogHRESULT("Criação de buffer", -1);
+#endif
     
     DRIFT_LOG_INFO("=== Demonstração de Log Concluída ===");
 }
@@ -261,19 +266,19 @@ void DemonstrateAdvancedFeatures() {
             {
                 PROFILE_SCOPE_WITH_PARENT("RHI", "Inicialização");
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
-                LOG_PERF("RHI inicializado");
+                DRIFT_LOG_DEBUG("[PERF] RHI inicializado");
             }
             
             {
                 PROFILE_SCOPE_WITH_PARENT("Audio", "Inicialização");
                 std::this_thread::sleep_for(std::chrono::milliseconds(50));
-                LOG_PERF("Audio inicializado");
+                DRIFT_LOG_DEBUG("[PERF] Audio inicializado");
             }
             
             {
                 PROFILE_SCOPE_WITH_PARENT("Input", "Inicialização");
                 std::this_thread::sleep_for(std::chrono::milliseconds(30));
-                LOG_PERF("Input inicializado");
+                DRIFT_LOG_DEBUG("[PERF] Input inicializado");
             }
         }
         


### PR DESCRIPTION
## Summary
- close Drift namespace in logging headers
- expose `GetTimestamp` and add cross-platform `FAILED` helper
- guard HRESULT logging on non-Windows platforms
- add `<iomanip>` include for asset system
- update logging examples to use DRIFT macros

## Testing
- `./build_core.sh`

------
https://chatgpt.com/codex/tasks/task_e_688ad55328e08325beb57a9739b7c8d5